### PR TITLE
Added tests for class-based traversal optimization

### DIFF
--- a/macros/test/MacroTest.scala
+++ b/macros/test/MacroTest.scala
@@ -45,7 +45,9 @@ class MacroTest extends FlatSpec with Matchers with TreeProvider {
       classOf[traversal.universe.Apply],
       classOf[traversal.universe.ApplyToImplicitArgs],
       classOf[traversal.universe.ApplyImplicitView],
-      classOf[traversal.universe.UnApply]
+      classOf[traversal.universe.UnApply],
+      traversal.universe.pendingSuperCall.getClass,
+      traversal.universe.noSelfType.getClass
     )
 
     validation should be (true)
@@ -75,7 +77,9 @@ class MacroTest extends FlatSpec with Matchers with TreeProvider {
       classOf[traversal.universe.Ident],
       classOf[traversal.universe.Apply],
       classOf[traversal.universe.ApplyToImplicitArgs],
-      classOf[traversal.universe.ApplyImplicitView]
+      classOf[traversal.universe.ApplyImplicitView],
+      traversal.universe.pendingSuperCall.getClass,
+      traversal.universe.noSelfType.getClass
     )
 
     validation should be (true)
@@ -91,6 +95,304 @@ class MacroTest extends FlatSpec with Matchers with TreeProvider {
     }
 
     traversal.classes should be (None)
+  }
+
+  abstract class Extractor(val universe : MacroTest.this.global.type) extends OptimizingTraversal {
+    import universe._
+
+    type State = List[Tree]
+    def emptyState = Nil
+
+    def add(tree : Tree) : Unit = transform(tree :: _)
+  }
+
+  def verifyMatching(optimized : Extractor, normal : Extractor) : Unit = {
+    val book = fromFile("traversal/AddressBook.scala")
+    val interp = fromFile("traversal/SimpleInterpreter.scala")
+
+    global.ask { () =>
+      optimized.traverse(book)
+      normal.traverse(book)
+      assert(optimized.result == normal.result, "Matching failed on AddressBook.scala")
+    }
+
+    global.ask { () =>
+      optimized.traverse(interp)
+      normal.traverse(interp)
+      assert(optimized.result == normal.result, "Matching failed on SimpleInterpreter.scala")
+    }
+  }
+
+  "Quasiquote matching" should "work for var defs" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$mods var $name : $tpt = $rhs" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$mods var $name : $tpt = $rhs" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for val defs" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$mods val $name : $tpt = $rhs" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$mods val $name : $tpt = $rhs" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for def defs" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$mods def $name(..$args) : $tpt = $rhs" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$mods def $name(..$args) : $tpt = $rhs" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for assignments" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$a = $b" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$a = $b" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for selects" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$a.$b" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$a.$b" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for apply" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$a(..$bs)" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$a(..$bs)" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work on for comprehensions" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"for (..$cs) $b" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"for (..$cs) $b" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work on for-yield comprehensions" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"for (..$cs) yield $b" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"for (..$cs) yield $b" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for match statements" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree @ q"$a match { case ..$cs }" => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree @ q"$a match { case ..$cs }" => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  "Subtype matching" should "work for binds" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : Bind => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : Bind => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for match statements" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : Match => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : Match => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for idents" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : Ident => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : Ident => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for selects" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : Select => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : Select => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for def defs" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : DefDef => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : DefDef => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for val defs" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : ValDef => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : ValDef => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for assignments" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : Assign => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : Assign => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
+  }
+
+  it should "work for apply" in {
+    val optimized = new Extractor(global) {
+      import universe._
+      val step = optimize { case tree : Apply => add(tree) }
+    }
+
+    val normal = new Extractor(global) {
+      import universe._
+      val step : PartialFunction[Tree,Unit] = {
+        case tree : Apply => add(tree)
+      }
+    }
+
+    verifyMatching(optimized, normal)
   }
 
 }


### PR DESCRIPTION
I added some tests for optimized traversal to verify that the class extraction matches the same stuff as what is matched by the patterns and the tests actually found a few issues! One should be careful when extending the optimizing traversal macro since all sub-type classes must be captured by the optimization.

It would be a good idea to supplement these tests with more standalone scala sources in macros/test-resources if you have some lying around to make sure we catch all possible tree types. The tests can be extended to the new resources simply by modifying the MacroTest.verifyMatching method.
