### PR TITLE
Fixing documentation links for rules

### DIFF
--- a/wiki/akka-rules.md
+++ b/wiki/akka-rules.md
@@ -11,7 +11,7 @@ TODO: this requirement should be made more flexible by people who know more abou
 ## Sender method called in deferred block
 
 name : **sender-in-future**  
-source : [SenderInFuture](/rules/akka/src/SenderInFuture.scala)
+source : [SenderInFuture](/rules/akka/src/main/scala/com/typesafe/abide/akka/SenderInFuture.scala)
 
 The `sender()` method should _never_ be called inside of a code block that won't be executed immediately in the `receive` method since the resulting sender might not be the right one anymore when the deferred code is actually executed. For example, the code
 ```scala
@@ -38,7 +38,7 @@ to make sure the sender we use to reply is indeed the one associated to the rece
 ## Closing over actor context
 
 name : **closing-over-context**  
-source : [ClosingOverContext](/rules/akka/src/ClosingOverContext.scala)
+source : [ClosingOverContext](/rules/akka/src/main/scala/com/typesafe/abide/akka/ClosingOverContext.scala)
 
 The actor `context` shouldn't be used in `Flow.onComplete`  
 TODO: a real explanation :)

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -5,7 +5,7 @@ Style rules that apply to all (or most) Scala code and are (mostly) non-controve
 ## Unused local definitions
 
 name : **unused-member**  
-source : [UnusedMember](/rules/core/src/UnusedMember.scala)
+source : [UnusedMember](/rules/core/src/main/scala/com/typesafe/abide/core/UnusedMember.scala)
 
 Definitions that cannot be accessed outside of the current scope should _always_ be used in the current scope. If this is not the case, then these definitions shouldn't exist as they reduce code readability by bloating the current scope.
 
@@ -17,7 +17,7 @@ This rule applies to:
 ## Public mutable fields
 
 name : **public-mutable-fields**  
-source : [PublicMutable](/rules/core/src/PublicMutable.scala)
+source : [PublicMutable](/rules/core/src/main/scala/com/typesafe/abide/core/PublicMutable.scala)
 
 Class and objects shouldn't expose mutable values (or variables) through their public API, such members should be hidden behind a transformation API to ensure good behaviour.
 
@@ -29,14 +29,14 @@ Are considered invalid mutable fields:
 ## Renamed default parameters in override
 
 name : **renamed-default-parameter**  
-source : [RenamedDefaultParameter](/rules/core/src/RenamedDefaultParameter.scala)
+source : [RenamedDefaultParameter](/rules/core/src/main/scala/com/typesafe/abide/core/RenamedDefaultParameter.scala)
 
 Method arguments that have default values should _never_ have their names swapped when overriding the method as this can have extremely unexpected behaviour (see [ScalaPuzzlers](http://scalapuzzlers.com/#pzzlr-024)).
 
 ## Unexpected recursive definitions
 
 name : **stupid-recursion**  
-source : [StupidRecursion](/rules/core/src/StupidRecursion.scala)
+source : [StupidRecursion](/rules/core/src/main/scala/com/typesafe/abide/core/StupidRecursion.scala)
 
 Parameterless methods shouldn't be recursive as such code is unclear and requires atypical termination conditions. Typically, one would not write such code, but a common programming pattern is member delegation on trait (or abstract class) instantiation. If one doesn't prefix the delegated member with the correct scoping information, we get a recursive definition (which can be valid, yet unwanted, Scala code).
 
@@ -54,14 +54,14 @@ the `Container.with` method is valid Scala code but will generate a never-ending
 ## Variables that are never assigned
 
 name : **local-val-instead-of-var** and **member-val-instead-of-var**  
-source : [ValInsteadOfVar](/rules/core/src/ValInsteadOfVar.scala)
+source : [ValInsteadOfVar](/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala)
 
 Private (or local) `var` definitions that have no assignment should actually be defined as `val` to clarify intent.
 
 ## Matching `Seq`-typed value with `::`
 
 name : **match-case-on-seq**  
-source : [MatchCaseOnSeq](/rules/core/src/MatchCaseOnSeq.scala)
+source : [MatchCaseOnSeq](/rules/core/src/main/scala/com/typesafe/abide/core/MatchCaseOnSeq.scala)
 
 When performing case matching, `Seq` typed scrutinees should not be deconstructed by `::` case statements since this reduces typing clarity. For example, the following snippet
 ```scala

--- a/wiki/extensions.md
+++ b/wiki/extensions.md
@@ -51,7 +51,7 @@ Any rule whose generator is transitively subsumed by another generator will be a
 
 In order to specify to the framework which generators are provided by a package, analyzer generator classes must be appended to the abide-plugin.xml descriptor in an `<analyzer class="some.analyzer.generator.Class" />` element.
 
-For a concrete example, see [NaiveTraversalAnalyzer](/abide/src/traversal/NaiveTraversalAnalyzer.scala) which is subsumed by [FusingTraversalAnalyzer](/abide/src/traversal/FusingTraversalAnalyzer.scala) for traversal rules.
+For a concrete example, see [NaiveTraversalAnalyzer](/abide/src/main/scala/scala/tools/abide/traversal/NaiveTraversalAnalyzer.scala) which is subsumed by [FusingTraversalAnalyzer](/abide/src/main/scala/scala/tools/abide/traversal/FusingTraversalAnalyzer.scala) for traversal rules.
 
 As of now, only the analyzer for unit-local, flow-agnostic rules has been written, but cross-unit and flow-sensitive
 backends should be added in the future (if deemed useful). However, many simple(r) rules do not actually need flow

--- a/wiki/extra-rules.md
+++ b/wiki/extra-rules.md
@@ -5,6 +5,6 @@ The rules found in this package form a complement to the [rules/core](/wiki/core
 ## Fixing the overriden method parameter names
 
 name : **fixed-name-overrides**  
-source : [FixedNameOverrides](/rules/extra/src/FixedNameOverrides.scala)
+source : [FixedNameOverrides](/rules/extra/src/main/scala/com/typesafe/abide/extra/FixedNameOverrides.scala)
 
 When overriding a method, it can be worthwhile to keep the argument names (and ordering) to make sure the source remains clear and easily readable when traversing a hierarchy. This rule will enforce such consistent naming and provide warnings when the names differ on method override.

--- a/wiki/rules.md
+++ b/wiki/rules.md
@@ -55,9 +55,9 @@ Finally, the `name` value provides a human-readable interface to **abide** rules
 A [traversal rule](/wiki/traversal/traversal-rules.md) is used when verification can be performed by a single unstructured pass through the unit-local (typed) source AST. This is typically the case for context-independent rules where bad patterns can be identified without requiring any knowledge of surrounding code, but more subtle types of properties can also be verified without requiring multiple passes.
 
 Examples of such rules can be found at
-- [vars which are never assigned](/rules/samples/src/ValInsteadOfVar.scala)
-- [unused members / arguments / locals](/rules/samples/src/UnusedMember.scala)
-- [renaming parameters with defaults in override](/rules/samples/src/RenamedDefaultParameter.scala)
+- [vars which are never assigned](/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala)
+- [unused members / arguments / locals](/rules/core/src/main/scala/com/typesafe/abide/core/UnusedMember.scala)
+- [renaming parameters with defaults in override](/rules/core/src/main/scala/com/typesafe/abide/core/RenamedDefaultParameter.scala)
 - ...
 
 ## Moar rulez!

--- a/wiki/traversal/existential-rules.md
+++ b/wiki/traversal/existential-rules.md
@@ -9,7 +9,7 @@ def nok(key : Key, warning : Warning) : Unit
 ```
 that will validate (`ok`), respectively invalidate (`nok`), these keys. The `Key` type remains an abstract member of the `ExistentialRule` type since different types of keys can be used in different concrete rules. Note that `nok` also takes a `Warning` argument that specifies the concrete warning that will be output by the rule if the associated key remains invalid after a full AST traversal.
 
-To showcase an `ExistentialRule` usage example, we will present a rule that checks that every private `var` member of a class is assigned somewhere in the class body (or it should be a `val`). Since we can't assume anything about declaration / assignment ordering, we use `ExistentialRule` as a base-trait and validate assignments while invalidating variable declarations. You can see the full source at [ValInsteadOfVar](/rules/samples/src/ValInsteadOfVar.scala).
+To showcase an `ExistentialRule` usage example, we will present a rule that checks that every private `var` member of a class is assigned somewhere in the class body (or it should be a `val`). Since we can't assume anything about declaration / assignment ordering, we use `ExistentialRule` as a base-trait and validate assignments while invalidating variable declarations. You can see the full source at [ValInsteadOfVar](/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala).
 
 Let us start by defining the rule class:
 ```scala

--- a/wiki/traversal/scoping-rules.md
+++ b/wiki/traversal/scoping-rules.md
@@ -9,7 +9,7 @@ will add `owner` to the scoping stack and the `state` provider can be queried to
 def in(owner : Onwer) : Boolean
 ```
 
-To illustrate `ScopingRule` usage, we will implement a recursive method definition checker that searches for weird definitions that point to themselves (see the full source at [StupidRecursion](/rules/samples/src/StupidRecursion.scala)).
+To illustrate `ScopingRule` usage, we will implement a recursive method definition checker that searches for weird definitions that point to themselves (see the full source at [StupidRecursion](/rules/core/src/main/scala/com/typesafe/abide/core/StupidRecursion.scala)).
 
 We start by defining the rule class:
 ```scala

--- a/wiki/traversal/warning-rules.md
+++ b/wiki/traversal/warning-rules.md
@@ -1,6 +1,6 @@
 # Writing Warning Rules
 
-Let us illustrate the `WarningRule` base-trait by writing a rule that makes sure overrides don't change argument names (see [FixedNameOverrides](/rules/samples/src/FixedNameOverrides.scala) for the full source). Since the typing phase will provide us with symbols for all definitions that a particular member overrides, we only need local information to verify whether a definition is valid or not, and we can verify the rule in a single pass through the program AST. Therefore, the `WarningRule` trait is exactly what we need!
+Let us illustrate the `WarningRule` base-trait by writing a rule that makes sure overrides don't change argument names (see [FixedNameOverrides](/rules/extra/src/main/scala/com/typesafe/abide/extra/FixedNameOverrides.scala) for the full source). Since the typing phase will provide us with symbols for all definitions that a particular member overrides, we only need local information to verify whether a definition is valid or not, and we can verify the rule in a single pass through the program AST. Therefore, the `WarningRule` trait is exactly what we need!
 
 The `WarningRule` trait defines a `State` type that simply accumulates warnings. These warnings are added to the state by invoking the `nok(warning : Warning) : Unit` helper provided by the `WarningRule trait. This is pretty much the simplest way possible of generating warnings during a traversal.
 


### PR DESCRIPTION
Most of the wiki links to Scala source files were broken from #4. This fixes all the wiki links that I could find.
