### PR TITLE
Warn about by-name right associative operators

### DIFF
--- a/rules/core/src/main/resources/abide-plugin.xml
+++ b/rules/core/src/main/resources/abide-plugin.xml
@@ -6,4 +6,5 @@
   <rule class="com.typesafe.abide.core.LocalValInsteadOfVar" />
   <rule class="com.typesafe.abide.core.MemberValInsteadOfVar" />
   <rule class="com.typesafe.abide.core.UnusedMember" />
+  <rule class="com.typesafe.abide.core.ByNameRightAssociative" />
 </plugin>

--- a/rules/core/src/main/scala/com/typesafe/abide/core/ByNameRightAssociative.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/ByNameRightAssociative.scala
@@ -1,0 +1,24 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class ByNameRightAssociative(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "by-name-right-associative"
+
+  case class Warning(defDef: DefDef) extends RuleWarning {
+    val pos = defDef.pos
+    val message = "By-name parameters will be evaluated eagerly when used in right-associative infix operators. For more details, see SI-1980."
+  }
+
+  def isByName(param: Symbol) = param.tpe.typeSymbol == definitions.ByNameParamClass
+
+  val step = optimize {
+    case defDef @ DefDef(_, name, _, params :: _, _, _) =>
+      if (!treeInfo.isLeftAssoc(name.decodedName) && params.exists(p => isByName(p.symbol))) {
+        nok(Warning(defDef))
+      }
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/ByNameRightAssociativeTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/ByNameRightAssociativeTest.scala
@@ -1,0 +1,85 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class ByNameRightAssociativeTest extends TraversalTest {
+
+  val rule = new ByNameRightAssociative(context)
+
+  "Right-associative operators" should "be valid when not using by-name parameters" in {
+    val tree = fromString("""
+      class Test {
+        def m_:(x: Int) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "not be valid when using by-name parameters" in {
+    val tree = fromString("""
+      class Test {
+        def m_:(x: => Int) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid for each method with by-name parameters" in {
+    val tree = fromString("""
+      class Test {
+        def m_:(x: => Int) = ()
+        def m2_:(x: => Int, y: => Char) = ()
+        private def m3_:(x: Int, y: => Char) = ()
+        private def m4_:(x: Int) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(3) }
+  }
+
+  it should "not be valid with by-name parameters in the first argument list" in {
+    val tree = fromString("""
+      class Test {
+        def op3_:(x: Any, y: => Any)(a: Any) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid with by-name parameters in the second argument list" in {
+    val tree = fromString("""
+      class Test {
+        def op6_:(x: Any)(a: => Any) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  "Left associative operators" should "be valid when using by-name parameters" in {
+    val tree = fromString("""
+      class Test {
+        def m(x: => Int) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "be valid when not using by-name parameters" in {
+    val tree = fromString("""
+      class Test {
+        def m(x: => Int) = ()
+        def m2(x: => Int, y: => Char) = ()
+        def m3(x: Int, y: => Char) = ()
+        def m4(x: Int) = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -77,3 +77,27 @@ should be written as
   case Nil => 0
 }
 ```
+
+## Avoiding by-name right-associative operators
+
+name : **by-name-right-associative**  
+source : [ByNameRightAssociative](/rules/extra/src/main/scala/com/typesafe/abide/extra/ByNameRightAssociative.scala)
+
+By-name arguments given to right-associative operators (those ending in `_:`)
+will be evaluated before the call to the operator rather than at the argument's use in the operator's body.
+
+### Example
+
+```scala
+def foo(): Int = { println("foo"); 1 }
+
+class C {
+  def op_:(x: => Int) = println("bar")
+}
+
+foo() op_: (new C) // Prints "foo" then "bar"
+
+(new C).op_:(foo()) // Prints just "bar"
+```
+
+The user most likely expects that in both cases only "bar" will be printed.


### PR DESCRIPTION
Warnings for the issue presented in SI-1980: https://issues.scala-lang.org/browse/SI-1980
