### PR TITLE
Rule for PackageObjectClasses

### DIFF
--- a/rules/core/src/main/resources/abide-plugin.xml
+++ b/rules/core/src/main/resources/abide-plugin.xml
@@ -7,4 +7,5 @@
   <rule class="com.typesafe.abide.core.MemberValInsteadOfVar" />
   <rule class="com.typesafe.abide.core.UnusedMember" />
   <rule class="com.typesafe.abide.core.ByNameRightAssociative" />
+  <rule class="com.typesafe.abide.core.PackageObjectClasses" />
 </plugin>

--- a/rules/core/src/main/scala/com/typesafe/abide/core/PackageObjectClasses.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/PackageObjectClasses.scala
@@ -1,0 +1,27 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class PackageObjectClasses(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "package-object-classes"
+
+  case class Warning(val pos: Position, symbol: Symbol) extends RuleWarning {
+    val message =
+      s"""It is not recommended to define classes inside of package objects.
+         |If possible, define ${symbol} in ${symbol.owner.owner} instead.""".stripMargin
+  }
+
+  def isPackageObjectMember(sym: Symbol) =
+    sym.owner.isModuleClass && sym.owner.name == tpnme.PACKAGE && !sym.isSynthetic
+
+  val step = optimize {
+    case cd @ ClassDef(_, _, _, _) if isPackageObjectMember(cd.symbol) =>
+      nok(Warning(cd.pos, cd.symbol))
+
+    case md @ ModuleDef(_, _, _) if isPackageObjectMember(md.symbol) =>
+      nok(Warning(md.pos, md.symbol))
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/PackageObjectClassesTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/PackageObjectClassesTest.scala
@@ -1,0 +1,54 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class PackageObjectClassesTest extends TraversalTest {
+
+  val rule = new PackageObjectClasses(context)
+
+  "Class definitions" should "not be valid if in a package object" in {
+    val tree = fromString("""
+      package object test {
+        class A
+        case class B()
+        private class C { def x: Int = 3 }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(3) }
+  }
+
+  it should "be valid if not in a package object" in {
+    val tree = fromString("""
+      package test2 {
+        class A
+        case class B()
+        private class C { def x: Int = 3 }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  "Object definitions" should "not be valid if in a pacakge object" in {
+    val tree = fromString("""
+      package object test {
+        object D
+        object E
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  it should "be valid if not in a package object" in {
+    val tree = fromString("""
+      package test2 {
+        object D
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -101,3 +101,11 @@ foo() op_: (new C) // Prints "foo" then "bar"
 ```
 
 The user most likely expects that in both cases only "bar" will be printed.
+
+## Avoiding class or object declarations inside package objects
+
+name : **package-object-classes**  
+source : [PackageObjectClasses](/rules/extra/src/main/scala/com/typesafe/abide/extra/PackageObjectClasses.scala)
+
+It is not recommended to define classes or objects inside of package objects,
+as they do not always work as expected.  See [SI-4344](https://issues.scala-lang.org/browse/SI-4344) for more details.


### PR DESCRIPTION
Warnings for the issue presented in SI-4344: https://issues.scala-lang.org/browse/SI-4344

Unlike the current `-Xlint` warning, this rule also warns about objects defined in package objects (as in the example at the link above). It is currently in `core` as was the case with `ByNameRightAssociative`.
