### PR TITLE
Rule for nullary methods of Unit type.

### DIFF
--- a/rules/core/src/main/resources/abide-plugin.xml
+++ b/rules/core/src/main/resources/abide-plugin.xml
@@ -8,4 +8,5 @@
   <rule class="com.typesafe.abide.core.UnusedMember" />
   <rule class="com.typesafe.abide.core.ByNameRightAssociative" />
   <rule class="com.typesafe.abide.core.PackageObjectClasses" />
+  <rule class="com.typesafe.abide.core.NullaryUnit" />
 </plugin>

--- a/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala
@@ -1,0 +1,32 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class NullaryUnit(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "nullary-unit"
+
+  case class Warning(val pos: Position, name: Name) extends RuleWarning {
+    val message = s"Side-effecting nullary methods are discouraged: try defining as `def $name()` instead"
+  }
+
+  // Don't warn for e.g. the implementation of a generic method being parameterized on Unit
+  def isOk(sym: Symbol) = (
+    sym.isGetter
+    || (sym.name containsName nme.DEFAULT_GETTER_STRING)
+    || sym.allOverriddenSymbols.exists(over => !(over.tpe.resultType =:= sym.tpe.resultType))
+  )
+
+  def check(df: Tree) = df.symbol.tpe match {
+    case NullaryMethodType(resttp) if resttp =:= typeOf[Unit] && !isOk(df.symbol) =>
+      nok(Warning(df.pos, df.symbol.name))
+    case _ => ()
+  }
+
+  val step = optimize {
+    case valDef @ ValDef(_, _, _, _)       => check(valDef)
+    case defDef @ DefDef(_, _, _, _, _, _) => check(defDef)
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/NullaryUnitTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/NullaryUnitTest.scala
@@ -1,0 +1,71 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class NullaryUnitTest extends TraversalTest {
+
+  val rule = new NullaryUnit(context)
+
+  "Nullary methods" should "be valid when their return type is not unit" in {
+    val tree = fromString("""
+      class Test {
+        def nullary1 = 1
+        def nullary2 = "2"
+        def nullary3 = '3'
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid when they return unit" in {
+    val tree = fromString("""
+      class Test {
+        def unit = ()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid when their return type is unit" in {
+    val tree = fromString("""
+      class Test {
+        def nullary: Unit = 23
+        def notNullary: Int = 23
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if they have type parameters" in {
+    val tree = fromString("""
+      class Test {
+        def nullaryP[T]: Unit = ()
+        def nullaryP2[T, U] = println("hello")
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid for each nullary method returning unit" in {
+    val tree = fromString("""
+      class Test {
+        private def nullaryUnit = ()
+        def nullaryNotUnit = 23
+        def nonNullaryUnit() = ()
+        def paramNullary[T] = ()
+        var x = 1
+        def moreComplicatedNullary = {
+          println("start")
+          x = x * 2
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -81,7 +81,7 @@ should be written as
 ## Avoiding by-name right-associative operators
 
 name : **by-name-right-associative**  
-source : [ByNameRightAssociative](/rules/extra/src/main/scala/com/typesafe/abide/extra/ByNameRightAssociative.scala)
+source : [ByNameRightAssociative](/rules/core/src/main/scala/com/typesafe/abide/core/ByNameRightAssociative.scala)
 
 By-name arguments given to right-associative operators (those ending in `_:`)
 will be evaluated before the call to the operator rather than at the argument's use in the operator's body.
@@ -105,7 +105,14 @@ The user most likely expects that in both cases only "bar" will be printed.
 ## Avoiding class or object declarations inside package objects
 
 name : **package-object-classes**  
-source : [PackageObjectClasses](/rules/extra/src/main/scala/com/typesafe/abide/extra/PackageObjectClasses.scala)
+source : [PackageObjectClasses](/rules/core/src/main/scala/com/typesafe/abide/core/PackageObjectClasses.scala)
 
 It is not recommended to define classes or objects inside of package objects,
 as they do not always work as expected.  See [SI-4344](https://issues.scala-lang.org/browse/SI-4344) for more details.
+
+## Avoiding nullary methods with `Unit` as their return type
+
+name : **nullary-unit**  
+source : [NullaryUnit](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala)
+
+It is not recommended to define methods with side-effects which take no arguments, as it is easy to accidentally invoke those side-effects.


### PR DESCRIPTION
Warns when a nullary method's result type is Unit. Based on the `-Xlint` rule with the same name. Its code can be found at https://github.com/scala/scala/blob/2.11.x/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L1587

Also fixed some dead links in the wiki from my previous pull requests.
