### PR TITLE
Comparing unrelated types with equals

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/EqualsWithDifferentTypes.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/EqualsWithDifferentTypes.scala
@@ -1,0 +1,27 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.Context
+import scala.tools.abide.traversal.WarningRule
+
+class EqualsWithDifferentTypes(val context: Context) extends WarningRule {
+
+  import context.universe._
+
+  val name = "equals-with-different-types"
+
+  case class Warning(appl: Apply) extends RuleWarning {
+    val pos = appl.pos
+    val message = "equals with different types will always return false"
+  }
+
+  val step = optimize {
+    case appl @ Apply(Select(lhs, TermName("$eq$eq")), List(rhs)) if !(lhs.tpe.erasure =:= rhs.tpe.erasure) =>
+
+      val bothNumerical = rhs.tpe.typeSymbol.isNumericValueClass && lhs.tpe.typeSymbol.isNumericValueClass
+      if (!bothNumerical) {
+        nok(Warning(appl))
+      }
+
+  }
+
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/EqualsWithDifferentTypesTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/EqualsWithDifferentTypesTest.scala
@@ -1,0 +1,40 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal.TraversalTest
+
+class EqualsWithDifferentTypesTest extends TraversalTest {
+
+  val rule = new EqualsWithDifferentTypes(context)
+
+  "Using equals with different types" should "give a warning" in {
+    val tree = fromString("""
+      class Test {
+        "a" == 1
+        Set() == List()
+      } """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  "Using equals with different types that will be implicitly converted" should "not give a warning" in {
+    val tree = fromString("""
+      class Test {
+        1.0 == 1
+        1.0F == 1.0
+      } """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  "Using equals with the same type" should "not give a warning" in {
+    val tree = fromString("""
+      class Test {
+        1 == 1
+        "a" == "b"
+        List() == List()
+      } """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -109,3 +109,13 @@ source : [PackageObjectClasses](/rules/extra/src/main/scala/com/typesafe/abide/e
 
 It is not recommended to define classes or objects inside of package objects,
 as they do not always work as expected.  See [SI-4344](https://issues.scala-lang.org/browse/SI-4344) for more details.
+
+## Comparing different types with equals
+
+name : **equals-with-different-types**
+source : [EqualsWithDifferentTypes](/rules/core/src/main/scala/com/typesafe/abide/core/EqualsWithDifferentTypes.scala)
+
+The contract of equals on the JVM states that objects who are not of the same type (class) may never be equal,
+still the signature of equals takes an object so it is possible to do equals comparisons that will never be true
+by calling it with an object of a different type.
+


### PR DESCRIPTION
Ported from scapegoat. Will warn if comparing unrelated types with equals (which will always return false according to contract)