### PR TITLE
Warn on usage of isInstanceOf and asInstanceOf 

### DIFF
--- a/rules/extra/src/main/scala/com/typesafe/abide/extra/InstancefOfUsed.scala
+++ b/rules/extra/src/main/scala/com/typesafe/abide/extra/InstancefOfUsed.scala
@@ -1,0 +1,26 @@
+package com.typesafe.abide.extra
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class InstancefOfUsed(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "instance-of-used"
+
+  case class Warning(tree: Tree, which: String) extends RuleWarning {
+    val pos = tree.pos
+    val message = s"Using $which. Consider using pattern matching instead."
+  }
+
+  private val AsInstanceOf = TermName("asInstanceOf")
+  private val IsInstanceOf = TermName("isInstanceOf")
+  val step = optimize {
+    case appl @ Select(_, AsInstanceOf) =>
+      nok(Warning(appl, "asInstanceOf"))
+
+    case appl @ Select(_, IsInstanceOf) =>
+      nok(Warning(appl, "isInstanceOf"))
+  }
+
+}

--- a/rules/extra/src/test/scala/com/typesafe/abide/extra/InstanceOfUsedTest.scala
+++ b/rules/extra/src/test/scala/com/typesafe/abide/extra/InstanceOfUsedTest.scala
@@ -1,0 +1,27 @@
+package com.typesafe.abide.extra
+
+import scala.tools.abide.traversal.TraversalTest
+
+class InstanceOfUsedTest extends TraversalTest {
+
+  val rule = new InstancefOfUsed(context)
+
+  "usages of asInstanceOf[T]" should "give a warning" in {
+    val tree = fromString("""
+      class Test {
+        val a = 1.asInstanceOf[Any]
+      }""")
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  "usages of isInstanceOf[T]" should "give a warning" in {
+    val tree = fromString("""
+      class Test {
+        val a = 1.isInstanceOf[Any]
+      }""")
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+}

--- a/wiki/extra-rules.md
+++ b/wiki/extra-rules.md
@@ -8,3 +8,10 @@ name : **fixed-name-overrides**
 source : [FixedNameOverrides](/rules/extra/src/main/scala/com/typesafe/abide/extra/FixedNameOverrides.scala)
 
 When overriding a method, it can be worthwhile to keep the argument names (and ordering) to make sure the source remains clear and easily readable when traversing a hierarchy. This rule will enforce such consistent naming and provide warnings when the names differ on method override.
+
+## Usage of isInstanceOf and asInstanceOf instead of pattern matching
+
+name : **instance-of-used**
+source : [InstancefOfUsed](/rules/extra/src/main/scala/com/typesafe/abide/extra/InstanceOfUsed.scala)
+
+It is safer and more idiomatic to use pattern matching than to use isInstanceOf and asInstanceOf on objects


### PR DESCRIPTION
Two scapegoat rule combined into one abide rule, will warn if using isInstanceOf or asInstanceOf and recommend using pattern matching instead. Placed in the extra ruleset.
