### PR TITLE
Rule for inferences of Any

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/InferAny.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/InferAny.scala
@@ -1,0 +1,41 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class InferAny(val context: Context) extends PathRule {
+  import context.universe._
+
+  val name = "infer-any"
+
+  case class Warning(app: Tree, tpt: Tree) extends RuleWarning {
+    val pos = app.pos
+    val message = s"A type was inferred to be `${tpt.tpe.typeSymbol.name}`. This may indicate a programming error."
+  }
+
+  // Use PathRule to track whether the traversal is currently inside a synthetic method
+  // (for example a method generated for a case class) which should be ignored.
+  type Element = Unit
+  def inSyntheticMethod = state.last.nonEmpty
+  def enterSyntheticMethod() = enter(())
+
+  def containsAny(t: Type) =
+    t.contains(typeOf[Any].typeSymbol) || t.contains(typeOf[AnyVal].typeSymbol)
+
+  def isInferredAny(tree: Tree) = tree match {
+    case tpt @ TypeTree() => tpt.original == null && containsAny(tpt.tpe)
+    case _                => false
+  }
+
+  val step = optimize {
+    case df @ DefDef(_, _, _, _, _, _) if df.symbol.isSynthetic =>
+      enterSyntheticMethod()
+
+    case app @ Apply(TypeApply(fun, targs), args) if targs.exists(isInferredAny) && !inSyntheticMethod =>
+      val existsExplicitAny = args.map(_.tpe).exists(containsAny(_))
+      if (!existsExplicitAny) {
+        nok(Warning(app, targs.find(isInferredAny).get))
+      }
+  }
+
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/InferAnyTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/InferAnyTest.scala
@@ -1,0 +1,70 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class InferAnyTest extends TraversalTest {
+
+  val rule = new InferAny(context)
+
+  "Inferences of Any" should "not be valid if not annotated" in {
+    val tree = fromString("""
+      class Test {
+        List(1, 2, 3) contains "a"
+        1L to 10L contains 3
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  it should "not be valid in methods if not annotated" in {
+    val tree = fromString("""
+      class Test {
+        def get(x: => Option[Int]) = x getOrElse Some(5)
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if applied method is explicitly applied to Any" in {
+    val tree = fromString("""
+      class Test {
+        List(1, 2, 3) contains[Any] "a"
+        1L to 10L contains[Any] 3
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "be valid if the argument is explicitly ascribed Any" in {
+    val tree = fromString("""
+      class Test {
+        def get(x: => Option[Int]) = x getOrElse (Some(5): Any)
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid only once for case classes" in {
+    val tree = fromString("""
+      case class Test(x: Boolean = 1L to 10L contains 3)
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if Any is inferred as part of a tuple" in {
+    val tree = fromString("""
+      class Test {
+        ((1L to 10L) zip (11L to 20L)).contains((3, 15L))
+        ((1L to 10L) zip (11L to 20L)).contains(((3: Any), 15L))
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -118,6 +118,28 @@ source : [PackageObjectClasses](/rules/core/src/main/scala/com/typesafe/abide/co
 It is not recommended to define classes or objects inside of package objects,
 as they do not always work as expected.  See [SI-4344](https://issues.scala-lang.org/browse/SI-4344) for more details.
 
+## Inferences of `Any` or `AnyVal`
+
+name : **infer-any**  
+source : [InferAny](/rules/core/src/main/scala/com/typesafe/abide/core/InferAny.scala)
+
+The Scala compiler will often infer `Any` as the parameter to a polymorphic
+method. This is generally not what is desired and can lead to errors such as
+the following:
+
+```scala
+1L to 10L contains 3
+// => false
+```
+
+To avoid the warning in cases where this is intentional, simply specify the
+type explicitly:
+
+```scala
+1L to 10L contains[Any] 3
+1L to 10L contains (3: Any)
+```
+
 ## Avoiding nullary methods with `Unit` as their return type
 
 name : **nullary-unit**  


### PR DESCRIPTION
This rule warns on things which are probably programmer errors such as `1L to 10L contains 3`.
