### PR TITLE
Rule for Inaccessible

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/Inaccessible.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/Inaccessible.scala
@@ -1,0 +1,122 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class Inaccessible(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "inaccessible"
+
+  case class Warning(val pos: Position, methodName: Name, className: Name, inaccessibleClassName: Name) extends RuleWarning {
+    val message =
+      s"""Method $methodName in class $className references private class $inaccessibleClassName.
+         |Classes which cannot access $inaccessibleClassName may be unable to override $methodName""".stripMargin
+  }
+
+  implicit class SymbolOps(sym: Symbol) {
+    def isModuleOrModuleClass = sym.isModule || sym.isModuleClass
+
+    def isTopLevel = sym.owner.isPackageClass
+
+    def isLocalToBlock: Boolean = sym.owner.isTerm
+
+    def isEffectivelyFinal: Boolean = (
+      sym.isFinal
+      || sym.hasPackageFlag
+      || isModuleOrModuleClass && isTopLevel
+      || sym.isTerm && (sym.isPrivate || isLocalToBlock)
+    )
+
+    def isNotOverridden = {
+      if (sym.owner.isClass) {
+        val classOwner = sym.owner.asClass
+        if (classOwner.isSealed) {
+          classOwner.knownDirectSubclasses.forall(c => {
+            c.isEffectivelyFinal && c.typeSignature.declarations.exists(subSym => subSym.allOverriddenSymbols.contains(sym))
+          })
+        }
+        else classOwner.isEffectivelyFinal
+      }
+      else false
+    }
+
+    def isDeferred = (sym.flags & Flag.DEFERRED) != 0
+
+    def isEffectivelyFinalOrNotOverridden: Boolean = {
+      isEffectivelyFinal || (sym.isTerm && !isDeferred && isNotOverridden)
+    }
+
+    def isLessAccessibleThan(other: Symbol): Boolean = {
+      val tb = sym.accessBoundary(sym.owner)
+      val ob1 = other.accessBoundary(sym.owner)
+      val ob2 = ob1.linkedClassOfClass
+      var o = tb
+      while (o != NoSymbol && o != ob1 && o != ob2) {
+        o = o.owner
+      }
+      o != NoSymbol && o != tb
+    }
+
+    def hasAccessBoundary = sym.privateWithin != NoSymbol
+
+    def accessBoundary(base: Symbol): Symbol = {
+      def enclosingRootClass(s: Symbol): Symbol = s match {
+        case s: ClassSymbol => s
+        case _              => enclosingRootClass(s.owner)
+      }
+      if (sym.isPrivate || sym.isLocalToBlock) sym.owner
+      else if (sym.isProtected && sym.isStatic && sym.isJava) enclosingRootClass(sym)
+      else if (hasAccessBoundary) sym.privateWithin
+      else if (sym.isProtected) base
+      else enclosingRootClass(sym)
+    }
+  }
+
+  val step = optimize {
+    case defDef @ DefDef(_, name, _, _, _, _) if !defDef.symbol.isSynthetic =>
+      val member = defDef.symbol
+      val isConstructor = member.isMethod && member.asMethod.isConstructor
+      if (!isConstructor && !member.isEffectivelyFinalOrNotOverridden) {
+
+        def checkAccessibilityOfType(tpe: Type) = {
+          val inaccessible = lessAccessibleSymsInType(tpe, member)
+          // If the unnormalized type is accessible, that's good enough
+          if (inaccessible.isEmpty) ()
+          // Or if the normalized type is, that's good too
+          else if ((tpe ne tpe.normalize) && lessAccessibleSymsInType(tpe.dealiasWiden, member).isEmpty) ()
+          // Otherwise warn about the inaccessible syms in the unnormalized type
+          else inaccessible foreach (sym => {
+            nok(Warning(defDef.pos, name, sym.owner.name, sym.name))
+          })
+        }
+
+        // Types of the value parameters
+        mapParamss(member)(p => checkAccessibilityOfType(p.tpe))
+        // Upper bounds of type parameters
+        member.typeParams.map(_.info.bounds.hi.widen) foreach checkAccessibilityOfType
+      }
+
+      def lessAccessibleSymsInType(other: Type, memberSym: Symbol): List[Symbol] = {
+        val extras = other match {
+          case TypeRef(pre, _, args) =>
+            // Checking the prefix here gives us spurious errors on e.g. a
+            // private[process] object which contains a type alias, which
+            // normalizes to a visible type.
+            args filterNot (_ eq NoPrefix) flatMap (tp => lessAccessibleSymsInType(tp, memberSym))
+          case _ => Nil
+        }
+        if (lessAccessible(other.typeSymbol, memberSym)) other.typeSymbol :: extras
+        else extras
+      }
+
+      def lessAccessible(otherSym: Symbol, memberSym: Symbol): Boolean = (
+        (otherSym != NoSymbol)
+        && !otherSym.isProtected
+        && !otherSym.isTypeParameterOrSkolem
+        && !otherSym.isExistentiallyBound
+        && (otherSym isLessAccessibleThan memberSym)
+        && (otherSym isLessAccessibleThan memberSym.enclClass)
+      )
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/InaccessibleTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/InaccessibleTest.scala
@@ -1,0 +1,72 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class InaccessibleTest extends scala.tools.abide.traversal.TraversalTest {
+
+  val rule = new Inaccessible(context)
+
+  "Methods with private types" should "not be valid if those types are in their arguments" in {
+    val tree = fromString("""
+      class Test {
+        private class T
+        def method(x: T) = 2
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if those types are in their type bounds" in {
+    val tree = fromString("""
+      package test {
+        private[test] trait PrivateTrait
+
+        trait Trait {
+          def method[T <: PrivateTrait](x: T): T = x
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if those types are in their arguments' type parameters" in {
+    val tree = fromString("""
+      package test {
+        private[test] trait PrivateTrait
+
+        trait Trait {
+          def method(x: Map[Int, Set[PrivateTrait]]) = 5
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it is final" in {
+    val tree = fromString("""
+      class Test {
+        private trait Trait
+        final def method1(x: Trait) = 2
+        final def method2[T <: Trait](x: T) = x
+        final def method3(x: Map[Int, Set[Trait]]) = 5
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  "Methods without private types" should "be valid" in {
+    val tree = fromString("""
+      class Test {
+        trait T
+        def method(x: T) = 2
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -124,3 +124,23 @@ name : **nullary-unit**
 source : [NullaryUnit](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala)
 
 It is not recommended to define methods with side-effects which take no arguments, as it is easy to accidentally invoke those side-effects.
+
+## Usages of potentially inaccessible types
+
+name : **inaccessible**  
+source : [Inaccessible](/rules/core/src/main/scala/com/typesafe/abide/core/Inaccessible.scala)
+
+Referencing private types as part of a public interface can lead to methods
+being impossible to implement in certain cases. For example in the following
+piece of code, YourTrait cannot be extended outside of the `foo` package, even
+though it is publicly accessible.
+
+```scala
+package foo {
+  private[foo] trait PrivateType { }
+
+  trait YourTrait {
+    def implementMe(f: Int => (String, PrivateType)): Unit
+  }
+}
+```


### PR DESCRIPTION
Warn when defining publicly overridable methods which reference private types.

The checks are based off those in Xlint's implementation of the same rule: https://github.com/scala/scala/blob/2.11.x/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L1638