### PR TITLE
Rule for nullary overrides.

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/NullaryOverride.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/NullaryOverride.scala
@@ -1,0 +1,23 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class NullaryOverride(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "nullary-override"
+
+  case class Warning(defDef: DefDef) extends RuleWarning {
+    val pos = defDef.pos
+    val message = "Non-nullary method overrides nullary method"
+  }
+
+  val step = optimize {
+    case defDef @ DefDef(mods, name, tparams, List(List()), tpt, rhs) if defDef.symbol.asMethod.isOverride =>
+      val overrides = defDef.symbol.overrides
+      if (overrides.exists(_.paramLists.isEmpty)) {
+        nok(Warning(defDef))
+      }
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/NullaryOverrideTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/NullaryOverrideTest.scala
@@ -1,0 +1,106 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class NullaryOverrideTest extends TraversalTest {
+
+  val rule = new NullaryOverride(context)
+
+  "Non-nullary methods" should "be valid when not overriding anything" in {
+    val tree = fromString("""
+      class Test {
+        def nonNullary() = 123
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "be valid when overriding other non-nullary methods" in {
+    val tree = fromString("""
+      class Parent {
+        def nonNullary() = 123
+      }
+      class Child extends Parent {
+        override def nonNullary() = 456
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "not be valid when overriding nullary methods" in {
+    val tree = fromString("""
+      class Parent {
+        def nullary = 123
+      }
+      class Child extends Parent {
+        override def nullary() = 456
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be invalid only once when overriding an overridden nullary method" in {
+    val tree = fromString("""
+      class A {
+        def nullary = 123
+      }
+      class B extends A {
+        override def nullary = 456
+      }
+      class C extends B {
+        override def nullary() = 789
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be invalid only once when overriding multiple nullary methods" in {
+    val tree = fromString("""
+      trait A {
+        def nullary = 123
+      }
+      trait B {
+        def nullary = 456
+      }
+      trait C {
+        def nullary() = 789
+      }
+      class D extends A with B with C {
+        override def nullary() = 0
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  "Nullary methods" should "be valid when overriding non-nullary methods" in {
+    val tree = fromString("""
+      class Parent {
+        def nonNullary() = 123
+      }
+      class Child extends Parent {
+        override def nonNullary = 456
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "be valid when overriding other nullary methods" in {
+    val tree = fromString("""
+      class Parent {
+        def nonNullary = 123
+      }
+      class Child extends Parent {
+        override def nonNullary = 456
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -124,3 +124,21 @@ name : **nullary-unit**
 source : [NullaryUnit](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala)
 
 It is not recommended to define methods with side-effects which take no arguments, as it is easy to accidentally invoke those side-effects.
+
+## Avoiding overriding non-nullary methods with nullary methods
+
+name : **nullary-override**  
+source : [NullaryOverride](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryOverride.scala)
+
+Providing a nullary override of a non-nullary method can lead to confusing
+errors and should be avoided. Consider for example:
+
+```scala
+trait T1 { def m() = 1 }
+trait T2 { def m = 2 }
+
+(new T1 {}).m() // => 1
+(new T1 with T2 {}).m() // does not compile
+```
+
+Mixing in an additional trait causes previously correct code not to compile.


### PR DESCRIPTION
Warns when a non-nullary method is overriden by a nullary one.