### PR TITLE
Rule for PolyImplicitOverload

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/PolyImplicitOverload.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/PolyImplicitOverload.scala
@@ -1,0 +1,27 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class PolyImplicitOverload(val context: Context) extends WarningRule {
+  import context.universe._
+
+  val name = "poly-implicit-overload"
+
+  case class Warning(val pos: Position) extends RuleWarning {
+    val message: String =
+      "Parametrized overloaded implicit methods are not visible as view bounds"
+  }
+
+  val step = optimize {
+    case t @ Template(parents, self, body) =>
+      val clazz = t.tpe
+      clazz.declarations filter (x => x.isImplicit && x.typeParams.nonEmpty) foreach { sym =>
+        // implicit classes leave both a module symbol and a method symbol as residue
+        val alts = clazz.declaration(sym.name).alternatives filterNot (_.isModule)
+        if (alts.size > 1) {
+          nok(Warning(sym.pos))
+        }
+      }
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/PolyImplicitOverloadTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/PolyImplicitOverloadTest.scala
@@ -1,0 +1,71 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class PolyImplicitOverloadTest extends TraversalTest {
+
+  val rule = new PolyImplicitOverload(context)
+
+  "Implicit methods" should "be valid when monomorphic and not overloaded" in {
+    val tree = fromString("""
+      object Test {
+        implicit def meth(x: List[Int]): Map[Int, Int] = Map()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "be valid when polymorphic and not overloaded" in {
+    val tree = fromString("""
+      object Test {
+        implicit def meth[T](x: List[T]): Map[T, T] = Map()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "be valid when monomorphic and overloaded" in {
+    val tree = fromString("""
+      object Test {
+        implicit def meth(x: List[Int]): Map[Int, Int] = Map()
+        implicit def meth(x: Set[Int]): Map[Int, Int] = Map()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+
+  it should "not be valid when polymorphic and overloaded" in {
+    val tree = fromString("""
+      object Test {
+        implicit def meth[T](x: List[T]): Map[T, T] = Map()
+        implicit def meth[T](x: Set[T]): Map[T, T] = Map()
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  "Implicit classes" should "be valid" in {
+    val tree = fromString("""
+      package object foo {
+        implicit class Bar[T](val x: T) extends AnyVal {
+          def bippy = 1
+        }
+      }
+
+      package foo {
+        object Baz {
+          def main(args: Array[String]): Unit = {
+            "abc".bippy
+          }
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).isEmpty should be(true) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -146,3 +146,19 @@ name : **nullary-unit**
 source : [NullaryUnit](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala)
 
 It is not recommended to define methods with side-effects which take no arguments, as it is easy to accidentally invoke those side-effects.
+
+## Avoid overloaded polymorphic implicit methods
+
+name : **poly-implicit-overload**  
+source : [PolyImplicitOverload](/rules/core/src/main/scala/com/typesafe/abide/core/PolyImplicitOverload.scala)
+
+Overloaded polymorphic implicit methods are not visible as view bounds and should therefore be avoided.  For example, the following will not compile because no implicit view is available from `List[Int]` to `Map[Int, Int]`:
+
+```scala
+implicit def imp1[T](x: List[T]): Map[T, T] = Map()
+implicit def imp1[T](x: Set[T]): Map[T, T] = Map()
+
+def f[T <% Map[Int, Int]](x: T) = println("f")
+
+f[List[Int]](List(3)) // No implicit view available!
+```


### PR DESCRIPTION
Relevant Xlint code is at https://github.com/scala/scala/blob/2.11.x/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala