### PR TITLE
Rule for MissingInterpolator

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/MissingInterpolator.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/MissingInterpolator.scala
@@ -1,0 +1,110 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class MissingInterpolator(val context: Context) extends ScopingRule {
+  import context.universe._
+
+  val name = "missing-interpolator"
+
+  case class Warning(literal: Literal, name: Option[Name]) extends RuleWarning {
+    val pos: Position = literal.pos
+    val message: String = if (name.nonEmpty) {
+      s"Possible missing interpolator: detected an interpolated identifier `$$${name.get}`"
+    }
+    else {
+      s"Possible missing interpolator: detected an interpolated expression"
+    }
+  }
+
+  // PlausibleNames are names and booleans representing whether they can be
+  // used in interpolations. Implausible is used for shadowing previously
+  // plausible names.
+  abstract class PlausibleName(val name: Name, val isPlausible: Boolean)
+  case class Plausible(override val name: Name) extends PlausibleName(name, true)
+  case class Implausible(override val name: Name) extends PlausibleName(name, false)
+
+  // State is a pair representing a name in scope along with a boolean
+  // The boolean is true if literals in the current scope are recognizably not
+  // for interpolation (e.g. in implicitNotFound annotations)
+  type Owner = (Boolean, PlausibleName)
+
+  val InterpolatorCodeRegex = """\$\{.*?\}""".r
+  val InterpolatorIdentRegex = """\$[$\w]+""".r // note that \w doesn't include $
+
+  def requiresNoArgs(tp: Type): Boolean = tp match {
+    case PolyType(_, restpe)     => requiresNoArgs(restpe)
+    case MethodType(Nil, restpe) => requiresNoArgs(restpe) // May be a curried method - can't tell yet
+    case MethodType(p :: _, _)   => p.isImplicit // Implicit method requires no args
+    case _                       => true // Catches all others including NullaryMethodType
+  }
+
+  def isRecognizablyNotForInterpolation: Boolean = state.scope.headOption.map(_._1).getOrElse(false)
+  def isPlausible(m: Name) = state.scope.map(_._2).find(sn => sn.name == m).map(_.isPlausible).getOrElse(false)
+
+  def enterPlausible(symbols: Iterable[Symbol]) = {
+    if (!isRecognizablyNotForInterpolation) {
+      for (s <- symbols if s.alternatives.exists(sa => requiresNoArgs(sa.typeSignature)) && !isPlausible(s.name)) {
+        enter((false, Plausible(s.name)))
+      }
+    }
+  }
+  def enterImplausible(symbols: Iterable[Symbol]) = {
+    if (!isRecognizablyNotForInterpolation) {
+      for (s <- symbols if !requiresNoArgs(s.typeSignature) && isPlausible(s.name)) {
+        enter(false, (Implausible(s.name)))
+      }
+    }
+  }
+
+  def enterNotForInterpolation() = enter((true, state.scope.head._2))
+
+  val step = optimize {
+    case Apply(Select(Apply(RefTree(_, nme.StringContext), _), _), _) =>
+      enterNotForInterpolation()
+
+    case Apply(Select(New(RefTree(_, tpnme.implicitNotFound)), _), _) =>
+      enterNotForInterpolation()
+
+    case t @ Template(parents, self, body) =>
+      // Add all inherited members to scope
+      enterPlausible(t.tpe.members.sorted diff t.tpe.declarations.sorted)
+      // Also consider private declarations in the parent class to be plausible
+      enterPlausible(parents.flatMap(p => p.symbol.tpe.declarations).filter(_.isPrivate))
+      // Invalidate plausible names which are shadowed by implausible ones
+      enterImplausible(t.tpe.declarations)
+      // Add this template's declarations as plausible
+      enterPlausible(t.tpe.declarations)
+
+    case d @ DefDef(_, _, _, vparamss, _, _) =>
+      enterPlausible(vparamss.flatten.map(_.symbol))
+
+    case p @ PackageDef(pid, stats) =>
+      enterImplausible(pid.tpe.members)
+      enterPlausible(pid.tpe.members)
+
+    case Block(stats, expr) =>
+      def isDeclaration(tree: Tree) = tree match {
+        case ValDef(_, _, _, _) | DefDef(_, _, _, _, _, _) => true
+        case _ => false
+      }
+      val decls = stats.filter(isDeclaration(_)).map(_.symbol)
+      // This is imprecise, it acts as if all of a blocks declarations occur at
+      // the beginning of the block
+      enterPlausible(decls)
+      enterImplausible(decls)
+
+    case lit @ Literal(Constant(s: String)) if !isRecognizablyNotForInterpolation =>
+      def suspiciousExpr = InterpolatorCodeRegex findFirstIn s
+      def suspiciousIdents = InterpolatorIdentRegex findAllIn s map (id => newTermName(id drop 1))
+
+      // No warning on e.g. a string with only "$ident"
+      if (s contains ' ') {
+        if (suspiciousExpr.nonEmpty) nok(Warning(lit, None))
+        else suspiciousIdents find isPlausible foreach (sym => {
+          nok(Warning(lit, Some(sym)))
+        })
+      }
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/MissingInterpolatorTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/MissingInterpolatorTest.scala
@@ -1,0 +1,219 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class MissingInterpolatorTest extends TraversalTest {
+
+  val rule = new MissingInterpolator(context)
+
+  "String literal" should "not be valid if it contains quoted names of values in scope" in {
+    val tree = fromString("""
+      class A {
+        val bippy = 123
+
+        def f = "Put the $bippy in the $bippy" // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it contains quoted names of values not in scope" in {
+    val tree = fromString("""
+      class B {
+        val dingus = 123
+
+        def f = "Put the $bippy in the $bippy" // no warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid if it contains quoted code" in {
+    val delim = "\"\"\""
+    val tree = fromString("""
+      class C {
+        def f = """ + delim + """Put the ${println("bippy")} in the bippy!""" + delim + """
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it contains quoted names of methods defined in the same package" in {
+    val tree = fromString("""
+      package object test {
+        def aleppo = 9
+      }
+      package test {
+        class E {
+          def f = "$aleppo is a pepper and a city." // warn
+          def k = s"Just an interpolation of $aleppo" // no warn
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it contains quoted names of private methods defined in parent class" in {
+    val tree = fromString("""
+      class Bar {
+        private def bar = 8
+        if (bar > 8) ???       // use it to avoid extra warning
+      }
+      class Baz extends Bar {
+        def f = "$bar is private, shall we warn just in case?" // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it contains quoted names of methods which take no explicit arguments" in {
+    val tree = fromString("""
+      class G {
+        def greppo(n: Int) = ???
+        def zappos(n: Int)(implicit ord: math.Ordering[Int]) = ???
+        def hippo(implicit n: Int) = ???
+        def g = "$greppo takes an arg" // no warn
+        def z = "$zappos takes an arg too" // no warn
+        def h = "$hippo takes an implicit" // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it contains quoted names of methods which take explicit arguments" in {
+    val tree = fromString("""
+      class J {
+        def j = 8
+        class J2 {
+          def j(i: Int) = 2 * i
+          def jj = "shadowed $j"  // no warn
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "be valid in implicitNotFound annotations if it contains quoted names of objects not in scope" in {
+    val tree = fromString("""
+      package test {
+        @scala.annotation.implicitNotFound(msg = "Cannot construct a collection of type ${To} with elements of type ${Elem} based on a collection of type ${From}.") // no warn
+        trait CannotBuildFrom1[-From, -Elem, +To]
+
+        @scala.annotation.implicitNotFound("Cannot construct a collection of type ${To} with elements of type ${Elem} based on a collection of type ${From}.") // no warn
+        trait CannotBuildFrom2[-From, -Elem, +To]
+
+        import annotation._
+        @implicitNotFound(msg = "Cannot construct a collection of type ${To} with elements of type ${Elem} based on a collection of type ${From}.") // no warn
+        trait CannotBuildFrom3[-From, -Elem, +To]
+
+        @implicitNotFound("No Z in ${A}")   // no warn
+        class Z[A]
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid if it contains quoted names of methods with one overloaded alternatives which take no explicit arguments" in {
+    val tree = fromString("""
+      class Doo {
+        def beppo(i: Int) = 8 * i
+        def beppo = 8
+        class Dah extends Doo {
+          def f = "$beppo was a marx bros who saw dollars."  // warn
+        }
+        def g = "$beppo is overloaded" // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  it should "be valid if it contains quoted names of methods which take curried explicit arguments" in {
+    val tree = fromString("""
+      class Curry1 {
+        def bunko()(x: Int): Int = 5
+        def f1 = "I was picked up by the $bunko squad" // no warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid if it contains quoted names of unitary methods" in {
+    val tree = fromString("""
+      class Curry2 {
+        def groucho(): Int = 5
+        def f2 = "I salute $groucho" // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it contains quoted names of methods with many empty argument lists" in {
+    val tree = fromString("""
+      class Curry3 {
+        def dingo()()()()()(): Int = 5 // kind of nuts this can be evaluated with just 'dingo', but okay
+        def f3 = "I even salute $dingo" // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it contains quoted names of methods with many empty argument lists and type arguments" in {
+    val tree = fromString("""
+      class Curry4 {
+        def calico[T1, T2]()()(): Int = 5 // even nutsier
+        def f4 = "I also salute $calico" // warn 9
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it contains quoted names of methods with at least one non-empty argument list" in {
+    val tree = fromString("""
+      class Curry5 {
+        def palomino[T1, T2]()(y: Int = 5)(): Int = 5 // even nutsier
+        def f5 = "I draw the line at $palomino" // no warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid if it contains quoted names of values defined in the same method" in {
+    val tree = fromString("""
+      class Test {
+        def method() = {
+          val x = 3
+          def y = 5
+          val s = "1 + 2 + $x"
+          "1 + 2 + $y"
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  it should "not be valid if it contains a quoted name of a method parameter" in {
+    val tree = fromString("""
+      class Test {
+        def method(arg: Int) = "method's argument is $arg"
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -146,3 +146,10 @@ name : **nullary-unit**
 source : [NullaryUnit](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala)
 
 It is not recommended to define methods with side-effects which take no arguments, as it is easy to accidentally invoke those side-effects.
+
+## Warn on strings which appear to be missing interpolators
+
+name : **missing-interpolator**  
+source : [MissingInterpolator](/rules/core/src/main/scala/com/typesafe/abide/core/MissingInterpolator.scala)
+
+It is easy to forget the interpolator symbol when writing string interpolations, so this rule will warn when it finds strings with no interpolators which appear to be destined for interpolation.


### PR DESCRIPTION
The rule is implemented as a ScopingRule.  Upon entering Templates or
PackageDefs or Blocks all the plausible declarations they carry are added to
the scope.

Currently Blocks are processed as if their declarations were accessible from
any point within the block, which is imprecise.

Relevant Xlint code is at https://github.com/scala/scala/blob/841389bc6f879031a8d36a5ffcca5e3c0e1fdcef/src/compiler/scala/tools/nsc/typechecker/Typers.scala#L5146
Tests are the same as in the scala compiler.
