### PR TITLE
Rule for TypeParameterShadow

### DIFF
--- a/rules/core/src/main/scala/com/typesafe/abide/core/TypeParameterShadow.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/TypeParameterShadow.scala
@@ -1,0 +1,72 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class TypeParameterShadow(val context: Context) extends ScopingRule {
+  import context.universe._
+
+  val name = "type-parameter-shadow"
+
+  case class Warning(tp: TypeDef, sym1: Symbol, sym2: Option[Symbol]) extends RuleWarning {
+    val pos: Position = tp.pos
+    val message: String =
+      if (sym2.nonEmpty) s"Type parameter ${tp.name} defined in $sym1 shadows ${sym2.get} defined in ${sym2.get.owner}. You may want to rename your type parameter, or possibly remove it."
+      else s"Type parameter ${tp.name} defined in $sym1 shadows predefined type ${tp.name}"
+
+  }
+
+  // State is a pair of List[Symbol] (the declared type parameters) and Boolean
+  // (true if the declarer is a class or method or type member)
+  type Owner = Symbol
+
+  // Any of the types in scala.Predef could be shadowed
+  val predefTypes = List("List", "Double", "Float", "Long", "Int", "Char", "Short", "Byte", "Unit", "Boolean") ++ scala.reflect.runtime.universe.typeOf[scala.Predef.type].declarations.filter(_.isType).map(_.name.toString)
+
+  def getDeclaration(tp: TypeDef, scope: List[Owner]) = scope.find { sym =>
+    sym.name == tp.name && sym.isType
+  }
+
+  def enclClassOrMethodOrTypeMemberScope: List[Owner] = state.scope.dropWhile { sym =>
+    !sym.isClass && !sym.isMethod && !(sym.isType && !sym.isParameter)
+  }
+
+  def warnTypeParameterShadow(tparams: List[TypeDef], sym: Symbol) = {
+    if (!sym.isSynthetic) {
+      val tt = tparams.filter(_.name != typeNames.WILDCARD).foreach { tp =>
+        if (predefTypes.contains(tp.name.toString)) nok(Warning(tp, sym, None))
+        // We don't care about type params shadowing other type params in the same declaration
+        else {
+          getDeclaration(tp, enclClassOrMethodOrTypeMemberScope) foreach { prevTp =>
+            if (prevTp != tp.symbol) {
+              nok(Warning(tp, sym, Some(prevTp)))
+            }
+          }
+        }
+
+      }
+    }
+  }
+
+  def enterAll(possTypes: List[Symbol]) = possTypes.map(enter(_))
+
+  val step = optimize {
+    case t @ Template(parents, self, body) =>
+      enterAll(t.tpe.members.toList)
+    case p @ PackageDef(pid, stats) =>
+      enterAll(pid.tpe.members.toList)
+
+    case cd @ ClassDef(_, _, tparams, _) =>
+      enter(cd.symbol)
+      warnTypeParameterShadow(tparams, cd.symbol)
+      enterAll(tparams.map(_.symbol))
+    case dd @ DefDef(_, _, tparams, _, _, _) =>
+      enter(dd.symbol)
+      warnTypeParameterShadow(tparams, dd.symbol)
+      enterAll(tparams.map(_.symbol))
+    case td @ TypeDef(_, _, tparams, _) =>
+      enter(td.symbol)
+      warnTypeParameterShadow(tparams, td.symbol)
+      enterAll(tparams.map(_.symbol))
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/TypeParameterShadowTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/TypeParameterShadowTest.scala
@@ -1,0 +1,127 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class TypeParameterShadowTest extends TraversalTest {
+
+  val rule = new TypeParameterShadow(context)
+
+  "Method type parameter" should "not be valid if it shadows another type" in {
+    val tree = fromString("""
+      trait D
+      trait Test {
+        def foobar[D](in: D) = in.toString // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it shadows another type when nested" in {
+    val tree = fromString("""
+      trait Test {
+        def foobar[N[M[List[_]]]] = 1 // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it has the same name as another parameter in the same list" in {
+    val tree = fromString("""
+      trait Test {
+        def foobar[A, N[M[L[A]]]] = 1 // no warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  "Type member type parameter" should "not be valid if it shadows another type" in {
+    val tree = fromString("""
+      trait D
+      trait Test {
+        type MySeq[D] = Seq[D] // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it shadows another type when nested" in {
+    val tree = fromString("""
+      trait Test {
+        type E[M[List[_]]] = Int // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it has the same name as another parameter in the same list" in {
+    val tree = fromString("""
+      trait Test {
+        type G[A, M[L[A]]] = Int // no warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  "Class type parameter" should "not be valid if it shadows another type" in {
+    val tree = fromString("""
+      trait Test {
+        trait T
+        class Foo[T](t: T) { // warn
+          def bar[T](w: T) = w.toString // warn
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  it should "not be valid if it shadows another type when nested" in {
+    val tree = fromString("""
+      class C[M[List[_]]] // warn
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid if it has the same name as another parameter in the same list" in {
+    val tree = fromString("""
+      class F[A, M[L[A]]] // no warn
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "not be valid if the parameter's name is List" in {
+    val tree = fromString("""
+      class G[List] // warn
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if the parameter's name is Byte" in {
+    val tree = fromString("""
+      class F[Byte] // warn
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "not be valid if it shadows a type alias" in {
+    val tree = fromString("""
+      object TypeAliasTest {
+        type T = Int
+        class F[T] // warn
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -146,3 +146,16 @@ name : **nullary-unit**
 source : [NullaryUnit](/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala)
 
 It is not recommended to define methods with side-effects which take no arguments, as it is easy to accidentally invoke those side-effects.
+
+## Warn when type parameters shadow existing types
+
+name : **type-parameter-shadow**  
+source : [TypeParameterShadow](/rules/core/src/main/scala/com/typesafe/abide/core/TypeParameterShadow.scala)
+
+Declaring a type parameter with the same name as an existing type, such as `Byte`, will result in that type being shadowed. This leads to confusing errors where the type `Byte` is not actually `scala.Byte`:
+
+```scala
+def fail[String](f: (String) => Unit) = f("")
+```
+
+The code above results in a type error because `String` is not `java.lang.String`.


### PR DESCRIPTION
Uses a ScopingRule to track the types which have been defined. All the types in
`scala.Predef`, as well as some others like `Byte`, `Char`, etc. are treated as
already defined. Types brought into scope by import statements are not handled.

Relevant Xlint code is at https://github.com/scala/scala/blob/8259d24b8e1f1fee495d486e835ae7ac58b12013/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala#L604
