### PR TITLE
Reducing boilerplate for warning definitions

### DIFF
--- a/abide/src/main/scala/scala/tools/abide/Rule.scala
+++ b/abide/src/main/scala/scala/tools/abide/Rule.scala
@@ -62,7 +62,4 @@ trait Rule {
 
   /** The warning type we're dealing with in this rule. @see [[RuleWarning]] */
   type Warning <: RuleWarning
-
-  /** We require a name field to manage rules (enable/disable) and pretty-print them */
-  val name: String
 }

--- a/abide/src/main/scala/scala/tools/abide/traversal/ExistentialRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/ExistentialRule.scala
@@ -21,7 +21,8 @@ trait ExistentialRule extends TraversalRule with KeyedWarnings {
   def emptyState = State(Map.empty)
   case class State(map: Map[Key, Option[Warning]]) extends KeyedState {
     def warnings = map.flatMap(_._2).toList
-    def ok(key: Key): State = State(map + (key -> None))
+
+    private[ExistentialRule] def ok(key: Key): State = State(map + (key -> None))
 
     /**
      * Marks a key as possibly invalid until an ok is found or traversal ends (in which case the key is considered as globally invalid).
@@ -29,7 +30,8 @@ trait ExistentialRule extends TraversalRule with KeyedWarnings {
      *
      * required by [[KeyedState]]
      */
-    def nok(key: Key, warning: Warning): State = State(map + (key -> map.getOrElse(key, Some(warning))))
+    override private[traversal] def nok(key: Key, warning: Warning): State =
+      State(map + (key -> map.getOrElse(key, Some(warning))))
   }
 
   /** Marks a key as valid forever */

--- a/abide/src/main/scala/scala/tools/abide/traversal/PathRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/PathRule.scala
@@ -21,10 +21,10 @@ trait PathRule extends TraversalRule with ScopingTraversal with IncrementalWarni
   def emptyState = State(Nil, Nil)
   case class State(path: List[Element], warnings: List[Warning]) extends IncrementalState {
     /** required by [[IncrementalState]] */
-    def nok(warning: Warning): State = State(path, warning :: warnings)
+    override private[traversal] def nok(warning: Warning): State = State(path, warning :: warnings)
 
-    def enter(element: Element): State = State(element :: path, warnings)
-    def leave: State = State(path.tail, warnings)
+    private[PathRule] def enter(element: Element): State = State(element :: path, warnings)
+    private[PathRule] def leave: State = State(path.tail, warnings)
 
     /** Provides access to the last element that was registered in the path */
     def last: Option[Element] = path.headOption

--- a/abide/src/main/scala/scala/tools/abide/traversal/PathRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/PathRule.scala
@@ -46,7 +46,4 @@ trait PathRule extends TraversalRule with ScopingTraversal with IncrementalWarni
 
   /** Register element as latest path element traversed (pushes onto path stack) */
   def enter(element: Element): Unit = { transform(_ enter element, _.leave) }
-
-  /** Reports a warning */
-  def nok(warning: Warning): Unit = { transform(_ nok warning) }
 }

--- a/abide/src/main/scala/scala/tools/abide/traversal/ScopingRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/ScopingRule.scala
@@ -37,7 +37,4 @@ trait ScopingRule extends TraversalRule with ScopingTraversal with IncrementalWa
 
   /** Register owner as current scope (pushes it onto scoping stack) */
   def enter(owner: Owner): Unit = { transform(_ enter owner, _.leave) }
-
-  /** Reports a warning */
-  def nok(warning: Warning): Unit = { transform(_ nok warning) }
 }

--- a/abide/src/main/scala/scala/tools/abide/traversal/ScopingRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/ScopingRule.scala
@@ -21,10 +21,10 @@ trait ScopingRule extends TraversalRule with ScopingTraversal with IncrementalWa
   def emptyState = State(Nil, Nil)
   case class State(scope: List[Owner], warnings: List[Warning]) extends IncrementalState {
     /** required by [[IncrementalState]] */
-    def nok(warning: Warning): State = State(scope, warning :: warnings)
+    private[traversal] def nok(warning: Warning): State = State(scope, warning :: warnings)
 
-    def enter(owner: Owner): State = State(owner :: scope, warnings)
-    def leave: State = State(scope.tail, warnings)
+    private[ScopingRule] def enter(owner: Owner): State = State(owner :: scope, warnings)
+    private[ScopingRule] def leave: State = State(scope.tail, warnings)
 
     def childOf(matches: Owner => Boolean): Boolean = scope.nonEmpty && matches(scope.head)
     def childOf(owner: Owner): Boolean = childOf(_ == owner)

--- a/abide/src/main/scala/scala/tools/abide/traversal/SimpleWarnings.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/SimpleWarnings.scala
@@ -1,0 +1,94 @@
+package scala.tools.abide.traversal
+
+import scala.reflect.macros._
+import scala.language.experimental.macros
+import scala.tools.abide.traversal._
+
+/**
+ * IncrementalWarnings
+ *
+ * Base trait provides an extension to [[RuleState]] which requires a transformation
+ * that adds a new warning to the accumulated set:
+ * ```scala
+ * def nok(warning: Warning): State
+ * ```
+ *
+ * We also refine the [[State]] type member to require an [[IncrementalState]] to
+ * guarantee all subtypes rules can register warnings with the `nok` transformer.
+ */
+trait IncrementalWarnings extends TraversalRule {
+  import context.universe._
+
+  /**
+   * IncrementalState
+   *
+   * Extension to [[RuleState]] that requires a transformer to register warnings
+   */
+  trait IncrementalState extends RuleState {
+    def nok(warning: Warning): State
+  }
+
+  /**
+   * The state type we'll be dealing with in subtype rules, required to be a subtype
+   * of the [[IncrementalState]] trait.
+   *
+   * @see [[IncrementalState]]
+   */
+  type State <: IncrementalState
+}
+
+/**
+ * SimpleWarnings
+ *
+ * Mixin trait for [[TraversalRule]] subtypes that lets users define warning
+ * messages with little to no boilerplate required. The trait provides an
+ * implicit StringContext wrapper that enables users to define the warning
+ * message simply as a string interpolation:
+ * ```scala
+ * val warning = w"This is a warning"
+ * ```
+ *
+ * Furthermore, the trait leverages the [[WarningExtractor.w]] macro to let
+ * users refer to the current tree the rule is visiting when registering a new
+ * warning:
+ * ```scala
+ * val warning = w"The code $tree is baaad"
+ * ```
+ *
+ * The [[warning]] definition type is a function of `Tree => String` so other
+ * warning definitions than string interpolations are also possible.
+ */
+trait SimpleWarnings extends IncrementalWarnings with WarningExtractor {
+  import context.universe._
+
+  /** provide the Warning type member of [[scala.tools.abide.Rule]] */
+  final class Warning(val tree: Tree, val message: String) extends RuleWarning {
+    val pos = tree.pos
+  }
+
+  /**
+   * WarningGenerator
+   *
+   * A function wrapper that provides some string transformations such
+   * as `stripMargin` that will be applied to the generatd message.
+   */
+  protected implicit class WarningGenerator(val f: Tree => String) extends (Tree => String) {
+    def apply(tree: Tree): String = f(tree)
+
+    /**
+     * stripMargin transformation applied on the generated warning message
+     *
+     * @see scala.collection.immutable.StringOps.stripMargin
+     */
+    def stripMargin: WarningGenerator = new WarningGenerator(tree => f(tree).stripMargin)
+  }
+
+  /** The warning message generator, either a function or a `w` string interpolation */
+  val warning: Tree => String
+
+  /**
+   * A helper function that lets users register warnings given their tree
+   * The [[warning]] function is used to transform the tree into a valid message.
+   */
+  def nok(tree: Tree): Unit = { transform(_ nok (new Warning(tree, warning(tree)))) }
+}

--- a/abide/src/main/scala/scala/tools/abide/traversal/SimpleWarnings.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/SimpleWarnings.scala
@@ -25,7 +25,7 @@ trait IncrementalWarnings extends TraversalRule {
    * Extension to [[RuleState]] that requires a transformer to register warnings
    */
   trait IncrementalState extends RuleState {
-    def nok(warning: Warning): State
+    private[traversal] def nok(warning: Warning): State
   }
 
   /**
@@ -78,7 +78,7 @@ trait KeyedWarnings extends TraversalRule {
    * An extension of [[RuleState]] that makes sure keyed warnings can be added to the state.
    */
   trait KeyedState extends RuleState {
-    def nok(key: Key, warning: Warning): State
+    private[traversal] def nok(key: Key, warning: Warning): State
   }
 
   /**
@@ -116,7 +116,7 @@ trait KeyedWarnings extends TraversalRule {
  * val warning = w"This is a warning"
  * ```
  *
- * Furthermore, the trait leverages the [[WarningExtractor.w]] macro to let
+ * Furthermore, the trait leverages the `WarningExtractor.w` macro to let
  * users refer to the current tree the rule is visiting when registering a new
  * warning:
  * ```scala

--- a/abide/src/main/scala/scala/tools/abide/traversal/WarningRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/WarningRule.scala
@@ -1,21 +1,25 @@
 package scala.tools.abide.traversal
 
+import scala.reflect.macros._
+import scala.language.experimental.macros
+
 import scala.reflect.internal.traversal._
 
 /**
  * WarningRule
  *
- * TraversalRule subtrait that provides the nok(warning : Warning) helper method to accumulate warnings. In this rule,
- * trees can be determined as invalid without requiring any extra context (ie. non-local information).
+ * TraversalRule subtrait that collects warnings based on local context only. We extend the [[IncrementalWarnings]] mixin trait
+ * to get simple warning definition with [[SimpleWarnings]] and reduce boilerplate for such rules.
  *
  * Since verification is run after typer, such rules are either quite simple and purely stylistic (public/private considerations) or
  * rely on tree.symbol information to provides a certain non-locallity to tree information (like overrides, overloads).
  */
-trait WarningRule extends TraversalRule {
+trait WarningRule extends TraversalRule with IncrementalWarnings {
   import context.universe._
 
   def emptyState = State(Nil)
-  case class State(warnings: List[Warning]) extends RuleState {
+  case class State(warnings: List[Warning]) extends IncrementalState {
+    /** required by [[IncrementalState]] */
     def nok(warning: Warning): State = State(warning :: warnings)
   }
 

--- a/abide/src/main/scala/scala/tools/abide/traversal/WarningRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/WarningRule.scala
@@ -22,7 +22,4 @@ trait WarningRule extends TraversalRule with IncrementalWarnings {
     /** required by [[IncrementalState]] */
     def nok(warning: Warning): State = State(warning :: warnings)
   }
-
-  /** Reports a warning */
-  def nok(warning: Warning): Unit = { transform(_ nok warning) }
 }

--- a/abide/src/main/scala/scala/tools/abide/traversal/WarningRule.scala
+++ b/abide/src/main/scala/scala/tools/abide/traversal/WarningRule.scala
@@ -20,6 +20,6 @@ trait WarningRule extends TraversalRule with IncrementalWarnings {
   def emptyState = State(Nil)
   case class State(warnings: List[Warning]) extends IncrementalState {
     /** required by [[IncrementalState]] */
-    def nok(warning: Warning): State = State(warning :: warnings)
+    override private[traversal] def nok(warning: Warning): State = State(warning :: warnings)
   }
 }

--- a/macros/src/main/scala/scala/tools/abide/traversal/WarningsMacro.scala
+++ b/macros/src/main/scala/scala/tools/abide/traversal/WarningsMacro.scala
@@ -1,0 +1,73 @@
+package scala.tools.abide.traversal
+
+import scala.reflect.macros._
+import scala.language.experimental.macros
+
+/**
+ * WarningExtractor
+ *
+ * Provide the extraction macro that uses the placeholder [[WarningExtractor.tree]] value in the
+ * [[WarningExtractor]] class with to create a function from Tree to String by replacing the
+ * dummy tree with the function parameter.
+ *
+ * To get the String we use the StringContext that we assume is the macro caller and
+ * apply the `StringContext.s` method to the transformed arguments. We also assume all
+ * references to `_.this.tree` refer to the [[WarningExtractor.tree]] value as checking for
+ * enclosing context is non-trivial and discouraged.
+ */
+object WarningExtractor {
+
+  /**
+   * Replacement macro implementation that replaces the placeholders with the returned
+   * function's argument tree.
+   *
+   * We have to use `c.untypecheck` on the `args` in to keep the ref-checks phase from
+   * crashing when traversing these trees. This should not be an issue as all types are pretty
+   * obvious here and typer should not be able to infer anything different.
+   */
+  def w_impl(c: blackbox.Context)(args: c.Tree*): c.Tree = {
+    import c.universe._
+
+    val valName: TermName = TermName(c.freshName("thisTree$"))
+    val valDef = q"val $valName : this.universe.Tree"
+
+    val cleanArgs = args map (tree => c.untypecheck(tree))
+    val newArgs = cleanArgs map (arg => c.internal.transform(arg) {
+      (tree, api) =>
+        tree match {
+          case Select(This(_), TermName("tree")) => Ident(valDef.name)
+          case _                                 => api.default(tree)
+        }
+    })
+
+    val sc = c.macroApplication match {
+      case Apply(Select(Apply(_, List(ctx)), TermName("w")), b) => ctx
+      case _ => c.abort(c.enclosingPosition, "Unexpected application, should be of the shape `w\"some text with $tree\"`")
+    }
+
+    q"($valDef => $sc.s(..$newArgs))"
+  }
+}
+
+/**
+ * WarningExtractor
+ *
+ * The trait that wraps the placeholder replacement macro and provides the
+ * StringContext wrapper that offers the `w` method.
+ */
+trait WarningExtractor {
+  val universe: Universe
+  import universe._
+
+  /**
+   * The placeholder tree that will be replaced by the parameter tree by the
+   * [[WarningHelper.w]] macro. We throw an exception if the value is read as
+   * this should never be the case!
+   */
+  final def tree: Tree = scala.sys.error("Should never happen")
+
+  /** StringContext wrapper that provides the `w` interpolator */
+  implicit class WarningHelper(val sc: StringContext) {
+    def w(args: Any*): (Tree => String) = macro WarningExtractor.w_impl
+  }
+}

--- a/rules/akka/src/main/scala/com/typesafe/abide/akka/ClosingOverContext.scala
+++ b/rules/akka/src/main/scala/com/typesafe/abide/akka/ClosingOverContext.scala
@@ -3,15 +3,10 @@ package com.typesafe.abide.akka
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class ClosingOverContext(val context: Context) extends ScopingRule {
+class ClosingOverContext(val context: Context) extends ScopingRule with SimpleWarnings {
   import context.universe._
 
-  val name = "closing-over-context"
-
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"Closing over Actor.context value in callback at $tree"
-  }
+  val warning = w"Closing over Actor.context value in callback at $tree"
 
   type Owner = Symbol
 
@@ -25,6 +20,6 @@ class ClosingOverContext(val context: Context) extends ScopingRule {
     case tree @ q"$caller(..$mat)(..$cb)" if onCompleteSym.map(caller.symbol.==).getOrElse(false) =>
       enter(caller.symbol)
     case s: Select if contextSym.map(s.symbol.==).getOrElse(false) && state.parent.isDefined =>
-      nok(Warning(s))
+      nok(s)
   }
 }

--- a/rules/akka/src/main/scala/com/typesafe/abide/akka/SenderInFuture.scala
+++ b/rules/akka/src/main/scala/com/typesafe/abide/akka/SenderInFuture.scala
@@ -3,15 +3,10 @@ package com.typesafe.abide.akka
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class SenderInFuture(val context: Context) extends PathRule {
+class SenderInFuture(val context: Context) extends PathRule with SimpleWarnings {
   import context.universe._
 
-  val name = "sender-in-future"
-
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"sender() is not stable and should not be accessed in non-thread-safe environments"
-  }
+  val warning = w"sender() is not stable and should not be accessed in non-thread-safe environments"
 
   sealed abstract class Element
   case class Receive(sym: Symbol) extends Element
@@ -36,7 +31,7 @@ class SenderInFuture(val context: Context) extends PathRule {
     }
     case tree @ Apply(sender @ Select(actor, TermName("sender")), _) if sender.symbol == senderSym =>
       if (state matches (Receive(actor.symbol), Future)) {
-        nok(Warning(tree))
+        nok(tree)
       }
   }
 }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/ByNameRightAssociative.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/ByNameRightAssociative.scala
@@ -3,22 +3,17 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class ByNameRightAssociative(val context: Context) extends WarningRule {
+class ByNameRightAssociative(val context: Context) extends WarningRule with SimpleWarnings {
   import context.universe._
 
-  val name = "by-name-right-associative"
-
-  case class Warning(defDef: DefDef) extends RuleWarning {
-    val pos = defDef.pos
-    val message = "By-name parameters will be evaluated eagerly when used in right-associative infix operators. For more details, see SI-1980."
-  }
+  val warning = w"By-name parameters will be evaluated eagerly when used in right-associative infix operators. For more details, see SI-1980."
 
   def isByName(param: Symbol) = param.tpe.typeSymbol == definitions.ByNameParamClass
 
   val step = optimize {
     case defDef @ DefDef(_, name, _, params :: _, _, _) =>
       if (!treeInfo.isLeftAssoc(name.decodedName) && params.exists(p => isByName(p.symbol))) {
-        nok(Warning(defDef))
+        nok(defDef)
       }
   }
 }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/EmptyOrNonEmptyUsingSize.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/EmptyOrNonEmptyUsingSize.scala
@@ -7,8 +7,6 @@ class EmptyOrNonEmptyUsingSize(val context: Context) extends WarningRule {
 
   import context.universe._
 
-  val name = "empty-nonempty-using-size"
-
   case class Warning(appl: Tree, empty: Boolean) extends RuleWarning {
     val pos = appl.pos
     val message = "Traversable.size is very expensive on some collections, use " +

--- a/rules/core/src/main/scala/com/typesafe/abide/core/InferAny.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/InferAny.scala
@@ -6,8 +6,6 @@ import scala.tools.abide.traversal._
 class InferAny(val context: Context) extends PathRule {
   import context.universe._
 
-  val name = "infer-any"
-
   case class Warning(app: Tree, tpt: Tree) extends RuleWarning {
     val pos = app.pos
     val message = s"A type was inferred to be `${tpt.tpe.typeSymbol.name}`. This may indicate a programming error."

--- a/rules/core/src/main/scala/com/typesafe/abide/core/MatchCaseOnSeq.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/MatchCaseOnSeq.scala
@@ -6,8 +6,6 @@ import scala.tools.abide.traversal._
 class MatchCaseOnSeq(val context: Context) extends WarningRule {
   import context.universe._
 
-  val name = "match-case-on-seq"
-
   case class Warning(scrut: Tree, mtch: Tree) extends RuleWarning {
     val pos = mtch.pos
     val message = s"Seq typed scrutinee $scrut shouldn't be matched against :: typed case $mtch"

--- a/rules/core/src/main/scala/com/typesafe/abide/core/NullaryOverride.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/NullaryOverride.scala
@@ -3,21 +3,16 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class NullaryOverride(val context: Context) extends WarningRule {
+class NullaryOverride(val context: Context) extends WarningRule with SimpleWarnings {
   import context.universe._
 
-  val name = "nullary-override"
-
-  case class Warning(defDef: DefDef) extends RuleWarning {
-    val pos = defDef.pos
-    val message = "Non-nullary method overrides nullary method"
-  }
+  val warning = w"Non-nullary method overrides nullary method"
 
   val step = optimize {
     case defDef @ DefDef(mods, name, tparams, List(List()), tpt, rhs) if defDef.symbol.asMethod.isOverride =>
       val overrides = defDef.symbol.overrides
       if (overrides.exists(_.paramLists.isEmpty)) {
-        nok(Warning(defDef))
+        nok(defDef)
       }
   }
 }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/NullaryUnit.scala
@@ -3,14 +3,10 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class NullaryUnit(val context: Context) extends WarningRule {
+class NullaryUnit(val context: Context) extends WarningRule with SimpleWarnings {
   import context.universe._
 
-  val name = "nullary-unit"
-
-  case class Warning(val pos: Position, name: Name) extends RuleWarning {
-    val message = s"Side-effecting nullary methods are discouraged: try defining as `def $name()` instead"
-  }
+  val warning = w"Side-effecting nullary methods are discouraged: try defining as `def ${tree.symbol.name}()` instead"
 
   // Don't warn for e.g. the implementation of a generic method being parameterized on Unit
   def isOk(sym: Symbol) = (
@@ -21,7 +17,7 @@ class NullaryUnit(val context: Context) extends WarningRule {
 
   def check(df: Tree) = df.symbol.tpe match {
     case NullaryMethodType(resttp) if resttp =:= typeOf[Unit] && !isOk(df.symbol) =>
-      nok(Warning(df.pos, df.symbol.name))
+      nok(df)
     case _ => ()
   }
 

--- a/rules/core/src/main/scala/com/typesafe/abide/core/PackageObjectClasses.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/PackageObjectClasses.scala
@@ -3,25 +3,20 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class PackageObjectClasses(val context: Context) extends WarningRule {
+class PackageObjectClasses(val context: Context) extends WarningRule with SimpleWarnings {
   import context.universe._
 
-  val name = "package-object-classes"
-
-  case class Warning(val pos: Position, symbol: Symbol) extends RuleWarning {
-    val message =
-      s"""It is not recommended to define classes inside of package objects.
-         |If possible, define ${symbol} in ${symbol.owner.owner} instead.""".stripMargin
-  }
+  val warning = w"""It is not recommended to define classes inside of package objects.
+                   |If possible, define ${tree.symbol} in ${tree.symbol.owner.owner} instead.""".stripMargin
 
   def isPackageObjectMember(sym: Symbol) =
     sym.owner.isModuleClass && sym.owner.name == tpnme.PACKAGE && !sym.isSynthetic
 
   val step = optimize {
     case cd @ ClassDef(_, _, _, _) if isPackageObjectMember(cd.symbol) =>
-      nok(Warning(cd.pos, cd.symbol))
+      nok(cd)
 
     case md @ ModuleDef(_, _, _) if isPackageObjectMember(md.symbol) =>
-      nok(Warning(md.pos, md.symbol))
+      nok(md)
   }
 }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/PublicMutable.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/PublicMutable.scala
@@ -13,8 +13,6 @@ class PublicMutable(val context: Context with MutabilityChecker) extends Warning
   import context._
   import universe._
 
-  val name = "public-mutable-fields"
-
   abstract class Warning(val tree: Tree) extends RuleWarning {
     val pos = tree.pos
     val name = tree.asInstanceOf[ValDef].name.toString.trim

--- a/rules/core/src/main/scala/com/typesafe/abide/core/RenamedDefaultParameter.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/RenamedDefaultParameter.scala
@@ -3,15 +3,10 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class RenamedDefaultParameter(val context: Context) extends WarningRule {
+class RenamedDefaultParameter(val context: Context) extends WarningRule with SimpleWarnings {
   import context.universe._
 
-  val name = "renamed-default-parameter"
-
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = "Renaming parameters with default values can lead to unexpected behavior"
-  }
+  val warning = w"Renaming parameters with default values can lead to unexpected behavior"
 
   val step = optimize {
     case defDef: DefDef =>
@@ -20,7 +15,7 @@ class RenamedDefaultParameter(val context: Context) extends WarningRule {
         (defDef.vparamss.flatten zip overriden.asMethod.paramLists.flatten).foreach {
           case (vd, o) =>
             if (vd.symbol.isParamWithDefault && vd.symbol.name != o.name && names(vd.symbol.name)) {
-              nok(Warning(vd))
+              nok(vd)
             }
         }
       }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/StupidRecursion.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/StupidRecursion.scala
@@ -3,21 +3,16 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class StupidRecursion(val context: Context) extends ScopingRule {
+class StupidRecursion(val context: Context) extends ScopingRule with SimpleWarnings {
   import context.universe._
 
   type Owner = Symbol
 
-  val name = "stupid-recursion"
-
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"The value $tree is recursively used in its directly defining scope"
-  }
+  val warning = w"The value $tree is recursively used in its directly defining scope"
 
   val step = optimize {
     case defDef @ q"def $name : $tpt = $body"                             => enter(defDef.symbol)
-    case id @ Ident(_) if id.symbol != null && (state childOf id.symbol)  => nok(Warning(id))
-    case s @ Select(_, _) if s.symbol != null && (state childOf s.symbol) => nok(Warning(s))
+    case id @ Ident(_) if id.symbol != null && (state childOf id.symbol)  => nok(id)
+    case s @ Select(_, _) if s.symbol != null && (state childOf s.symbol) => nok(s)
   }
 }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/UnusedMember.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/UnusedMember.scala
@@ -3,15 +3,12 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class UnusedMember(val context: Context) extends ExistentialRule {
+class UnusedMember(val context: Context) extends ExistentialRule with SimpleWarnings {
   import context.universe._
 
   type Key = Symbol
 
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"${tree.symbol} is not used."
-  }
+  val warning = w"${tree.symbol} is not used."
 
   private def shouldConsider(sym: Symbol): Boolean = {
     val owner = sym.owner
@@ -42,16 +39,16 @@ class UnusedMember(val context: Context) extends ExistentialRule {
 
   val step = optimize {
     case vd: ValDef if shouldConsider(vd.symbol) =>
-      nok(vd.symbol, Warning(vd))
+      nok(vd.symbol, vd)
 
     case dd: DefDef if shouldConsider(dd.symbol) =>
-      nok(dd.symbol, Warning(dd))
+      nok(dd.symbol, dd)
 
     case tree @ q"$pre.$name" =>
       ok(tree.symbol)
 
     case b: Bind =>
-      nok(b.symbol, Warning(b))
+      nok(b.symbol, b)
 
     case tree @ Ident(_) =>
       val affectedSymbols =

--- a/rules/core/src/main/scala/com/typesafe/abide/core/UnusedMember.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/UnusedMember.scala
@@ -6,7 +6,6 @@ import scala.tools.abide.traversal._
 class UnusedMember(val context: Context) extends ExistentialRule {
   import context.universe._
 
-  val name = "unused-member"
   type Key = Symbol
 
   case class Warning(tree: Tree) extends RuleWarning {

--- a/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala
@@ -3,21 +3,18 @@ package com.typesafe.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-trait ValInsteadOfVar extends ExistentialRule {
+trait ValInsteadOfVar extends ExistentialRule with SimpleWarnings {
   type Key = context.universe.Symbol
 }
 
 class LocalValInsteadOfVar(val context: Context) extends ValInsteadOfVar {
   import context.universe._
 
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"The `var` $tree was never assigned locally and should therefore be declared as a `val`"
-  }
+  val warning = w"The `var` $tree was never assigned locally and should therefore be declared as a `val`"
 
   val step = optimize {
     case varDef @ q"$mods var $name : $tpt = $value" if varDef.symbol.owner.isMethod =>
-      nok(varDef.symbol, Warning(varDef))
+      nok(varDef.symbol, varDef)
     case q"$rcv = $expr" =>
       ok(rcv.symbol)
   }
@@ -26,15 +23,12 @@ class LocalValInsteadOfVar(val context: Context) extends ValInsteadOfVar {
 class MemberValInsteadOfVar(val context: Context) extends ValInsteadOfVar {
   import context.universe._
 
-  case class Warning(tree: Tree) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"The member `var` $tree was never assigned locally and should therefore be declared as a `val`"
-  }
+  val warning = w"The member `var` $tree was never assigned locally and should therefore be declared as a `val`"
 
   val step = optimize {
     case varDef @ q"$mods var $name : $tpt = $value" =>
       val setter: Symbol = varDef.symbol.setter
-      if (setter.isPrivate) nok(varDef.symbol, Warning(varDef))
+      if (setter.isPrivate) nok(varDef.symbol, varDef)
     case set @ q"$setter(..$args)" if setter.symbol.isSetter =>
       ok(setter.symbol.accessed)
   }

--- a/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/ValInsteadOfVar.scala
@@ -10,8 +10,6 @@ trait ValInsteadOfVar extends ExistentialRule {
 class LocalValInsteadOfVar(val context: Context) extends ValInsteadOfVar {
   import context.universe._
 
-  val name = "local-val-instead-of-var"
-
   case class Warning(tree: Tree) extends RuleWarning {
     val pos = tree.pos
     val message = s"The `var` $tree was never assigned locally and should therefore be declared as a `val`"
@@ -27,8 +25,6 @@ class LocalValInsteadOfVar(val context: Context) extends ValInsteadOfVar {
 
 class MemberValInsteadOfVar(val context: Context) extends ValInsteadOfVar {
   import context.universe._
-
-  val name = "member-val-instead-of-var"
 
   case class Warning(tree: Tree) extends RuleWarning {
     val pos = tree.pos

--- a/rules/extra/src/main/scala/com/typesafe/abide/extra/FixedNameOverrides.scala
+++ b/rules/extra/src/main/scala/com/typesafe/abide/extra/FixedNameOverrides.scala
@@ -6,8 +6,6 @@ import scala.tools.abide.traversal._
 class FixedNameOverrides(val context: Context) extends WarningRule {
   import context.universe._
 
-  val name = "fixed-name-overrides"
-
   case class Warning(vd: ValDef, sn: String, sym: MethodSymbol) extends RuleWarning {
     val pos = vd.pos
     val message = s"Renaming parameter ${vd.name} of method ${vd.symbol.owner.name} from ${sn} in super-type ${sym.owner.name} can lead to confusion"

--- a/rules/extra/src/main/scala/com/typesafe/abide/extra/InstancefOfUsed.scala
+++ b/rules/extra/src/main/scala/com/typesafe/abide/extra/InstancefOfUsed.scala
@@ -3,24 +3,20 @@ package com.typesafe.abide.extra
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class InstancefOfUsed(val context: Context) extends WarningRule {
+class InstancefOfUsed(val context: Context) extends WarningRule with SimpleWarnings {
   import context.universe._
 
-  val name = "instance-of-used"
-
-  case class Warning(tree: Tree, which: String) extends RuleWarning {
-    val pos = tree.pos
-    val message = s"Using $which. Consider using pattern matching instead."
-  }
+  val warning = w"Use of ${tree.asInstanceOf[Select].name} is discouraged, consider using pattern matching instead"
 
   private val AsInstanceOf = TermName("asInstanceOf")
   private val IsInstanceOf = TermName("isInstanceOf")
+
   val step = optimize {
     case appl @ Select(_, AsInstanceOf) =>
-      nok(Warning(appl, "asInstanceOf"))
+      nok(appl)
 
     case appl @ Select(_, IsInstanceOf) =>
-      nok(Warning(appl, "isInstanceOf"))
+      nok(appl)
   }
 
 }

--- a/sbt-plugin/src/main/scala/scala/tools/abide/AbideSbtPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/tools/abide/AbideSbtPlugin.scala
@@ -93,7 +93,8 @@ object AbideSbtPlugin extends AutoPlugin {
         if (nRules > 0) {
           streams.value.log.info(s"Checking $nRules abide rules")
           abideObj.main(options.toArray)
-        } else
+        }
+        else
           streams.value.log.info(s"No abide rules found. Maybe you forgot to add dependencies on rule packages?")
       }
       else {

--- a/wiki/traversal/traversal-rules.md
+++ b/wiki/traversal/traversal-rules.md
@@ -14,6 +14,11 @@ In addition to being verifiable with a single pass, rules will typically share s
 
 3. [scoping rules](/wiki/traversal/scoping-rules.md) rely on scoping information (by mixing `ScopingTraversal` in) to verify program properties, a situation that will generally arise when verifying properties dealing with recursion or inner / outer relations. The `ScopingRule` interfaces provides helpers to manage and access scope during AST traversal to verify such properties.
 
+Also, many rules share the same basic warning structure of a message linked to a particular tree. In that case, one can mix the `SimpleWarnings` trait into the rule definition and simplify warning definition to filling out the `warning` value member of the rule with a function from `Tree` to `String`. Furthermore, a string interpolator `w` is provided as well that enables reference to the tree we are warning against in the message as well as even simpler definitions:
+```scala
+val warning = w"The code in $tree is bad!"
+```
+
 ## Adding new helper traits
 
 Many traversal rules can be implemented by using the previous helper base-traits, but some may require a slightly different state representation, or different helpers. Here are a few considerations to keep in mind when writing new traversal base-traits.


### PR DESCRIPTION
Adds a macro that enables much simpler warning definitions when the message only depends on a single tree.
Such warnings can be handled by mixing the SimpleWarnings class into the rule and defining the

``` scala
val warning: (Tree => String)
```

member. To make this simpler, I provide a `w` string interpolator macro that replaces all instances of a placeholder `tree` value in the string with the function argument Tree. This way, we can have a complete warning definition in one line:

``` scala
val warning = w"Bad code in $tree, abort abort!"
```

Since we're using a macro for replacement, this also works when accessing parts of the tree, such as w"${tree.symbol}".

Also, it seems that rules are going to be indexed through their complete class name (which makes sense), so requiring additional unique rule names is not really useful and just adds boilerplate to the rule definitions, so I removed them.
