### PR TITLE
Fix naming conflict

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,7 @@ object AbideBuild extends Build {
       mappings in (Compile, packageSrc) ++= (mappings in (macros, Compile, packageSrc)).value
     ).dependsOn(macros % "compile->compile;test->test")
 
-  lazy val sbt = Project("sbt-abide", file("sbt-plugin"))
+  lazy val sbtAbide = Project("sbt-abide", file("sbt-plugin"))
     .settings(sharedSettings : _*)
     .settings(
       sbtPlugin    := true,
@@ -54,7 +54,7 @@ object AbideBuild extends Build {
 
   lazy val rules = Seq(coreRules, akkaRules, extraRules)
 
-  lazy val allProjects = Seq(macros, abide, sbt) ++ rules
+  lazy val allProjects = Seq(macros, abide, sbtAbide) ++ rules
 
   lazy val filter = ScopeFilter(inAggregates(ThisProject, includeRoot=false))
 


### PR DESCRIPTION
As reported by @dancingrobot84 this fixes the name conflict in the project definition.

* change abide sbt plugin name: `sbt` -> `sbtAbide`

fixes #49 