### PR TITLE
Allow presenter extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ scalacOptions ++= Seq(
   "-P:abide:abidecp:<some.rules.classpath>",
   "-P:abide:ruleClass:<some.rule.Class>",
   "-P:abide:analyzerClass:<some.analyzer.generator.Module>",
+  "-P:abide:presenterClass:<some.presenter.generator.Module>",
   ...)
 ```
 or simply add these options to your call to `scalac` to enable **abide** during your standard compilation run.
@@ -68,6 +69,7 @@ scalac -Xplugin:<path/to/abide.jar>                            \
        -P:abide:abidecp:<some.rules.classpath>                 \
        -P:abide:ruleClass:<some.rule.Class>                    \
        -P:abide:analyzerClass:<some.analyzer.generator.Module> \
+       -P:abide:presenterClass:<some.presenter.generator.Module> \
        ...
 ```
 
@@ -99,6 +101,10 @@ When rule application can benefit from some global traversal logic, or partial t
 performed in an `Analyzer` subtype. These analyzers are typically non-trivial and will be integrated into the main **abide** deliverable to then be shared by all rules. However, analyzers can also be provided alongside rules in plugin
 libraries.
 
+4. [presenter extension](/wiki/extensions.md#defining-presenters)
+The **abide** framework initially ships with one presenter but provides a powerful extension point to accomodate user-defined
+presenters. These presenters can either be defined locally (using the `Project(...).dependsOn(rules % "abide")` construction) or shared over github by submitting new presenters as pull requests to this repository.
+
 The provided extension mechanism uses a plugin architecture based on an xml description that specifies plugin
 capabilities. This description sits at the base of the `resources` directory, in `abide-plugin.xml` and has the 
 following structure:
@@ -107,6 +113,7 @@ following structure:
   <rule class="some.rule.Class" />
   <rule class="some.other.rule.Class" />
   <analyzer class="some.analyzer.generator.Class" />
+  <presenter class="some.presenter.generator.Class" />
 </plugin>
 ```
 

--- a/abide/src/main/resources/abide-plugin.xml
+++ b/abide/src/main/resources/abide-plugin.xml
@@ -1,4 +1,5 @@
 <plugin>
   <analyzer class="scala.tools.abide.traversal.FusingTraversalAnalyzerGenerator" />
   <analyzer class="scala.tools.abide.traversal.NaiveTraversalAnalyzerGenerator" />
+  <presenter class="scala.tools.abide.presentation.ConsolePresenterGenerator" />
 </plugin>

--- a/abide/src/main/scala/scala/tools/abide/presentation/ConsolePresenter.scala
+++ b/abide/src/main/scala/scala/tools/abide/presentation/ConsolePresenter.scala
@@ -4,6 +4,17 @@ import scala.tools.nsc._
 import scala.tools.abide._
 
 /**
+ * ConsolePresenterGenerator
+ *
+ * @see [[ConsolePresenter]]
+ */
+object ConsolePresenterGenerator extends PresenterGenerator {
+  def getPresenter(global: Global): ConsolePresenter = {
+    new ConsolePresenter(global)
+  }
+}
+
+/**
  * ConsolePresenter
  *
  * Simple [[Presenter]] that outputs warnings as compiler warnings

--- a/abide/src/main/scala/scala/tools/abide/presentation/Presenter.scala
+++ b/abide/src/main/scala/scala/tools/abide/presentation/Presenter.scala
@@ -4,6 +4,24 @@ import scala.tools.nsc._
 import scala.tools.abide._
 
 /**
+ * Supertrait for presenter generator objects.
+ *
+ * The [[PresenterGenerator]] that will instantiate the [[Presenter]] necessary.
+ *
+ *
+ * @see [[presentation.ConsolePresenterGenerator]] for a concrete example
+ * @see [[Presenter]]
+ */
+trait PresenterGenerator {
+
+  /**
+   * Buils a new [[Presenter]]
+   */
+  def getPresenter(global: Global): Presenter
+
+}
+
+/**
  * Presenter
  *
  * Base class for result "presentation". A presenter instance will receive warnings as input

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,7 @@ object AbideBuild extends Build {
       mappings in (Compile, packageSrc) ++= (mappings in (macros, Compile, packageSrc)).value
     ).dependsOn(macros % "compile->compile;test->test")
 
-  lazy val sbt = Project("sbt-abide", file("sbt-plugin"))
+  lazy val sbtAbide = Project("sbt-abide", file("sbt-plugin"))
     .settings(sharedSettings : _*)
     .settings(
       sbtPlugin    := true,
@@ -54,7 +54,7 @@ object AbideBuild extends Build {
 
   lazy val rules = Seq(coreRules, akkaRules, extraRules)
 
-  lazy val allProjects = Seq(macros, abide, sbt) ++ rules
+  lazy val allProjects = Seq(macros, abide, sbtAbide) ++ rules
 
   lazy val filter = ScopeFilter(inAggregates(ThisProject, includeRoot=false))
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,45 +1,45 @@
 import sbt._
-import Keys._
+import sbt.Keys._
 
 object AbideBuild extends Build {
 
   lazy val abideSettings = Seq(
     organization := "com.typesafe",
-    version      := "0.1-SNAPSHOT"
+    version := "0.1-SNAPSHOT"
   )
 
   lazy val sharedSettings = Formatting.sbtFilesSettings ++ abideSettings ++ Seq(
-    scalaVersion                  := "2.11.4",
-    scalacOptions                ++= Seq("-Xfuture", "-deprecation", "-feature" /*, "-Xfatal-warnings"*/),
-    testOptions       in Test     += Tests.Argument("-oF"),
-    libraryDependencies          <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _ % "provided"),
-    libraryDependencies          <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _ % "provided"),
-    libraryDependencies           += "org.scalatest" %% "scalatest" % "2.1.7" % "test",
-    publishArtifact in Test       := false
+    scalaVersion := "2.11.4",
+    scalacOptions ++= Seq("-Xfuture", "-deprecation", "-feature" /*, "-Xfatal-warnings"*/),
+    testOptions in Test += Tests.Argument("-oF"),
+    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _ % "provided"),
+    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _ % "provided"),
+    libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.7" % "test",
+    publishArtifact in Test := false
   )
 
-  lazy val macros = Project("abide-macros", file("macros")).settings(sharedSettings : _*)
+  lazy val macros = Project("abide-macros", file("macros")).settings(sharedSettings: _*)
 
   lazy val abide = Project("abide", file("abide"))
-    .settings(sharedSettings : _*)
+    .settings(sharedSettings: _*)
     .settings(
-      mappings in (Compile, packageBin) ++= (mappings in (macros, Compile, packageBin)).value,
-      mappings in (Compile, packageSrc) ++= (mappings in (macros, Compile, packageSrc)).value
+      mappings in(Compile, packageBin) ++= (mappings in(macros, Compile, packageBin)).value,
+      mappings in(Compile, packageSrc) ++= (mappings in(macros, Compile, packageSrc)).value
     ).dependsOn(macros % "compile->compile;test->test")
 
   lazy val sbtAbide = Project("sbt-abide", file("sbt-plugin"))
-    .settings(sharedSettings : _*)
+    .settings(sharedSettings: _*)
     .settings(
-      sbtPlugin    := true,
+      sbtPlugin := true,
       scalaVersion := "2.10.4"
     )
 
   lazy val coreRules = Project("abide-core", file("rules/core"))
-    .settings(sharedSettings : _*)
+    .settings(sharedSettings: _*)
     .dependsOn(abide % "compile->compile;test->test")
 
   lazy val akkaRules = Project("abide-akka", file("rules/akka"))
-    .settings(sharedSettings : _*)
+    .settings(sharedSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-actor" % "2.3.3" % "test",
@@ -49,14 +49,14 @@ object AbideBuild extends Build {
     .dependsOn(abide % "compile->compile;test->test")
 
   lazy val extraRules = Project("abide-extra", file("rules/extra"))
-    .settings(sharedSettings : _*)
+    .settings(sharedSettings: _*)
     .dependsOn(abide % "compile->compile;test->test")
 
   lazy val rules = Seq(coreRules, akkaRules, extraRules)
 
   lazy val allProjects = Seq(macros, abide, sbtAbide) ++ rules
 
-  lazy val filter = ScopeFilter(inAggregates(ThisProject, includeRoot=false))
+  lazy val filter = ScopeFilter(inAggregates(ThisProject, includeRoot = false))
 
   lazy val root = (Project("root", file("."))
     .settings(
@@ -64,6 +64,6 @@ object AbideBuild extends Build {
       //test in Test      := (test in tests in Test).value,
       //parallelExecution in Global := false,
       packagedArtifacts := Map.empty
-    ) /: allProjects) (_ aggregate _)
+    ) /: allProjects)(_ aggregate _)
 
 }

--- a/wiki/extensions.md
+++ b/wiki/extensions.md
@@ -59,3 +59,29 @@ information and warnings can be collected by a single pass through a compilation
 _traversal rules_ in the **abide** lingo. See
 [writing traversal rules](/wiki/traversal/traversal-rules.md) and
 [abide rules](/wiki/rules.md) for more details.
+
+### Defining presenters
+
+In order to output results, **abide** relies on `Presenter` instances that know how to actually process the output of ***abide***.
+For example, the `ConsolePresenter` will output the results as compiler messages.
+
+When declaring a presenter, a generator type has to be attached to it so the framework will know how to actually create the presenter.
+A `PresenterGenerator` is an object that knows how to instantiate an `Presenter` given all the needed context and for it to run.
+
+```scala
+object SomePresenterGenerator extends PresenterGenerator {
+  def generatePresenter(global: Global) : Presenter =
+    new SomePresenter(global)
+}
+```
+
+```scala
+class SomePresenter(protected val global: Global) extends Presenter {
+
+  import global._
+
+  def apply(unit: CompilationUnit, warnings: List[Warning]): Unit = {
+    // TODO: implement the presenter
+  }
+}
+```


### PR DESCRIPTION
Add support for custom presenters, following the same idea behind the `Analyser` extension.

Each presenter has a `*Generator` and is passed as a parameter.

If there is no presenter passed, it will fallback to the `ConsolePresenter`.