### PR TITLE
Replace scalariform plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# SBT
+boot/
+lib_managed/
+target/
+.history
+
+# Eclipse
+.cache
+.classpath
+.project
+.scala_dependencies
+.settings
+.target/
+eclipse.sbt
+
 core/project/target
 core/target
 rules/project/target
@@ -6,8 +21,15 @@ project/target
 target
 *.swp
 *.BAK
-.classpath
-.project
 *.prefs
-.cache
 .tmpBin/
+
+# IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+
+# Mac
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,3 @@
-# SBT
-boot/
-lib_managed/
-target/
-.history
-
-# Eclipse
-.cache
-.classpath
-.project
-.scala_dependencies
-.settings
-.target/
-eclipse.sbt
-
 core/project/target
 core/target
 rules/project/target
@@ -21,15 +6,8 @@ project/target
 target
 *.swp
 *.BAK
+.classpath
+.project
 *.prefs
+.cache
 .tmpBin/
-
-# IntelliJ
-.idea/
-*.iml
-*.ipr
-*.iws
-out/
-
-# Mac
-.DS_Store

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
-


### PR DESCRIPTION
This PR introduces the [`scalariform`](https://github.com/sbt/sbt-scalariform) sbt plugin officially maintained / worked on at [`sbt/sbt-scalariform`](https://github.com/scala-ide).