### PR TITLE
New rule: avoid accidental use of Predef.synchronized in value classes

### DIFF
--- a/rules/core/src/main/resources/abide-plugin.xml
+++ b/rules/core/src/main/resources/abide-plugin.xml
@@ -9,4 +9,5 @@
   <rule class="com.typesafe.abide.core.ByNameRightAssociative" />
   <rule class="com.typesafe.abide.core.PackageObjectClasses" />
   <rule class="com.typesafe.abide.core.NullaryUnit" />
+  <rule class="com.typesafe.abide.core.ValueClassSynchronized" />
 </plugin>

--- a/rules/core/src/main/scala/com/typesafe/abide/core/ValueClassSynchronized.scala
+++ b/rules/core/src/main/scala/com/typesafe/abide/core/ValueClassSynchronized.scala
@@ -1,0 +1,27 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+final class ValueClassSynchronized(val context: Context) extends PathRule {
+  import context.universe._
+  import definitions.{Object_synchronized, PredefModule}
+
+  val name = "value-class-synchronized"
+  type Element = Symbol
+
+  case class Warning(ap: Apply) extends RuleWarning {
+    val pos = ap.pos
+    val message = "Within a user defined value class, `synchronized {}` locks `Predef`, which is unwise and probably unexpected"
+  }
+
+  private def enclosingClass = state.last.getOrElse(NoSymbol)
+
+  val step = optimize {
+    case tmpl: ImplDef =>
+      enter(tmpl.symbol)
+    case ap @ Apply(TypeApply(sel @ Select(qual, _), _), _) =>
+      if (enclosingClass.isDerivedValueClass && sel.symbol == Object_synchronized && qual.symbol == PredefModule)
+        nok(Warning(ap))
+  }
+}

--- a/rules/core/src/test/scala/com/typesafe/abide/core/ValueClassSynchronizedTest.scala
+++ b/rules/core/src/test/scala/com/typesafe/abide/core/ValueClassSynchronizedTest.scala
@@ -1,0 +1,50 @@
+package com.typesafe.abide.core
+
+import scala.tools.abide.traversal._
+import com.typesafe.abide.core._
+
+class ValueClassSynchronizedTest extends TraversalTest {
+
+  val rule = new ValueClassSynchronized(context)
+
+  it should "not be valid when accidentally calling Predef.synchronized" in {
+    val tree = fromString("""
+      class C(val self: AnyRef) extends AnyVal {
+        def foo = synchronized { toString }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(1) }
+  }
+
+  it should "be valid calling some other synchronized" in {
+    val tree = fromString("""
+      class C(val self: AnyRef) {
+        def foo = self.synchronized { toString }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "be valid outside of value class" in {
+    val tree = fromString("""
+      class C {
+        def foo = Predef.synchronized { toString }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  it should "be valid in class nested in value class" in {
+    val tree = fromString("""
+      class C(val self: AnyRef) {
+        def foo = { new { def foo = synchronized { toString } } }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+}

--- a/wiki/core-rules.md
+++ b/wiki/core-rules.md
@@ -244,3 +244,23 @@ c.toString() // => 0
 ```
 
 In this example `c.toString()` will always print `0`, even after calling `c.increment`.
+
+## Avoid accidental use of `Predef.synchronized` in Value Classes
+
+name : **value-class-synchronized**
+source : [ValueClassSynchronized](/rules/core/src/main/scala/com/typesafe/abide/core/ValueClassSynchronized.scala)
+
+User defined value classes extending `AnyVal` are not able to call `this.synchronized`. However, the common patten
+of writing `def foo = synchronized { ... } ` will still typecheck because of the automatic import of `Predef._`.
+
+
+```scala
+class Foo
+implicit class RichFoo(val self: Foo) extends AnyVal {
+  def sideEffect() = synchronized {
+    assert(Thread.holdsLock(Predef)) // probably unintended!
+  }
+}
+```
+
+Instead, use `self.synchronized { ... }` to lock on the wrapped object.


### PR DESCRIPTION
Review by @SethTisue. Not sure if this would come up in the wild, I only
stumbled across it looking for kindred bugs to one I'm fixing in specialization.
But I thought I'd use it as a chance to learn how to write an Abide rule.