### PR TITLE
[discussion PR] Discarded expressions rule

### DIFF
--- a/rules/core/src/main/scala/com/lightbend/abide/core/DiscardedExpression.scala
+++ b/rules/core/src/main/scala/com/lightbend/abide/core/DiscardedExpression.scala
@@ -3,7 +3,7 @@ package com.lightbend.abide.core
 import scala.tools.abide._
 import scala.tools.abide.traversal._
 
-class DiscardedExpression(val context: Context) extends ExistentialRule {
+class DiscardedExpression(val context: Context) extends WarningRule {
   import context.universe._
 
   val name = "discarded-expression"
@@ -24,7 +24,7 @@ class DiscardedExpression(val context: Context) extends ExistentialRule {
       }
 
       discarded.foreach { exp =>
-        nok(exp.symbol, Warning(exp))
+        nok(Warning(exp))
       }
   }
 }

--- a/rules/core/src/main/scala/com/lightbend/abide/core/DiscardedExpression.scala
+++ b/rules/core/src/main/scala/com/lightbend/abide/core/DiscardedExpression.scala
@@ -1,0 +1,31 @@
+package com.lightbend.abide.core
+
+import scala.tools.abide._
+import scala.tools.abide.traversal._
+
+class DiscardedExpression(val context: Context) extends ExistentialRule {
+  import context.universe._
+
+  val name = "discarded-expression"
+  type Key = Symbol
+
+  case class Warning(tree: Tree) extends RuleWarning {
+    val pos = tree.pos
+    val message = s"${tree.symbol} is discarded."
+  }
+
+  private val WarnPrefixes = List("Int", "foo.")
+
+  val step = optimize {
+    case Block(stats, _) =>
+      val discarded = stats.filter { s =>
+        val typeAsString = s.tpe.dealias.toString()
+        WarnPrefixes.exists(p => typeAsString.startsWith(p))
+      }
+
+      discarded.foreach { exp =>
+        nok(exp.symbol, Warning(exp))
+      }
+  }
+}
+

--- a/rules/core/src/test/scala/com/lightbend/abide/core/DiscardedExpressionTest.scala
+++ b/rules/core/src/test/scala/com/lightbend/abide/core/DiscardedExpressionTest.scala
@@ -1,0 +1,78 @@
+package com.lightbend.abide.core
+
+import scala.tools.abide.traversal._
+
+class DiscardedExpressionTest extends TraversalTest {
+
+  val rule = new DiscardedExpression(context)
+
+  "Discarded expressions" should "be discovered" in {
+    val tree = fromString("""
+      package foo {
+         class Bar()
+      }
+
+      class Toto {
+        def x() = 42
+        def y() = new foo.Bar()
+        def z() = {
+          x()
+          y()
+          "ok"
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(2) }
+  }
+
+  it should "be discovered when type aliased" in {
+    val tree = fromString("""
+      package foo {
+         class Bar()
+      }
+
+      class Toto {
+        type fb = foo.Bar
+        def x(): fb = new foo.Bar()
+        def z() = {
+          x()
+          "ok"
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be (1) }
+  }
+
+  "Used expressions" should "be valid" in {
+    val tree = fromString("""
+      class Toto {
+        def x() = 42
+        def y() = {
+          x()
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+
+  "Discarded expressions not on the warning list" should "be valid" in {
+    val tree = fromString("""
+      package baz {
+         class Bar()
+      }
+
+      class Toto {
+        def y() = new baz.Bar()
+        def z() = {
+          y()
+          "ok"
+        }
+      }
+    """)
+
+    global.ask { () => apply(rule)(tree).size should be(0) }
+  }
+}

--- a/rules/core/src/test/scala/com/lightbend/abide/core/DiscardedExpressionTest.scala
+++ b/rules/core/src/test/scala/com/lightbend/abide/core/DiscardedExpressionTest.scala
@@ -1,5 +1,6 @@
 package com.lightbend.abide.core
 
+import scala.tools.abide.AbideTest
 import scala.tools.abide.traversal._
 
 class DiscardedExpressionTest extends TraversalTest {


### PR DESCRIPTION
Following #67 & https://groups.google.com/forum/#!topic/scala-user/fIzON6Ss87A, we created a simple PoC which introduces a rule for checking if an expression in a block is discarded (as @dragos pointed out) - as you can see that's almost trivial. @mkubala is working on some more tests on a branch in our fork.

The main problem to solve is how to configure the rule. Currently there's a hard-coded list of type name prefixes which trigger a warning (currently-currently these are test values). I was thinking that maybe the plugin user would provide those - though I don't know what would be a good mechanism. E.g. for checking that akka's routes aren't discarded, the list should contain `akka.http.scaladsl.`. When using scalaz, this should include `scalaz.` - I think (almost?) every expression there is pure. Etc - these could be project-specific types as well. 

Secondly, I'm not sure how we should go about distributing the rule - once & if it is ready. Is there a chance for it to get accepted to `abide-core` or `abide-extras`? Or should we define our own plugin with this rule?